### PR TITLE
`-X theirs`

### DIFF
--- a/aylien/v1/news/config/php.json
+++ b/aylien/v1/news/config/php.json
@@ -1,6 +1,6 @@
 {
   "packageName": "aylien/newsapi",
-  "artifactVersion": "3.0.1",
+  "artifactVersion": "3.1.0",
   "invokerPackage": "Aylien\\NewsApi",
   "modelPackage": "Models",
   "apiPackage": "Api",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -32,6 +32,7 @@ cd ..
 
 echo "php: publishing to packagist"
 echo "- please note that packagist expects a new github release, and only updates the package in that case"
+echo "- you can also sign in at packagist.org and click 'update' manually for the package"
 echo "- using PACKAGIST_API_TOKEN from env"
 cd php
 lang=php

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -2,14 +2,14 @@ cd ../sdks/news-api
 
 release_note=${1:-"minor update"}
 
-function git_push {
+function git_push() {
   rm -rf .git
   git init
   git add .
   git commit -m "$release_note"
   git remote add origin git@github.com:aylien/aylien_newsapi_$lang
 
-  git pull origin master -s recursive -X ours
+  git pull origin master -s recursive -X theirs
   git cherry-pick --skip
   git rebase --continue
   git push origin master
@@ -18,7 +18,7 @@ function git_push {
 echo "javascript: publishing to npm"
 if [ ! -f "$HOME/.npmrc" ]; then
   echo "- $HOME/.npmrc not found, using NPM_AUTH_TOKEN from env to create it."
-  echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > $HOME/.npmrc
+  echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" >$HOME/.npmrc
 fi
 
 cd javascript
@@ -51,14 +51,14 @@ git_push
 pip install twine
 python setup.py sdist bdist_wheel
 twine check dist/*
-twine upload --non-interactive  -u $PYPI_USERNAME -p $PYPI_PASSWORD dist/*
+twine upload --non-interactive -u $PYPI_USERNAME -p $PYPI_PASSWORD dist/*
 cd ..
 
 echo "ruby: publishing to gems"
 if [ ! -f "$HOME/.gem/credentials" ]; then
   echo "- $HOME/.gem/credentials not found, using GEM_API_KEY from env to create it."
   mkdir -p $HOME/.gem
-  echo ":rubygems_api_key: $GEM_API_KEY" > $HOME/.gem/credentials
+  echo ":rubygems_api_key: $GEM_API_KEY" >$HOME/.gem/credentials
 fi
 cd ruby
 lang=ruby


### PR DESCRIPTION
from `man git rebase`:
> Note that a rebase merge works by replaying each commit from the working branch on top of the <upstream> branch. Because of this, when a merge
conflict happens, the side reported as ours is the so-far rebased series, starting with <upstream>, and theirs is the working branch. In other words,
the sides are swapped.

So the strategy names are swapped. `theirs` means your local changes, `ours` means the remote changes :man_facepalming: 