### PR TITLE
Coverages temp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ temp.api.yaml
 no-post.api.yaml
 # Dev
 .idea
+.vscode
 
 # Project specific
 openapi-generator*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 temp.api.yaml
+no-post.api.yaml
 # Dev
 .idea
 

--- a/aylien/v1/news/api-docs.yaml
+++ b/aylien/v1/news/api-docs.yaml
@@ -4982,22 +4982,16 @@ components:
       type: object
       properties:
         $and:
-          allOf:
-            - title: Logical operator And
-            - $ref: '#/components/schemas/Logical'
+          $ref: '#/components/schemas/Logical'
         $or:
-          allOf:
-            - title: Logical operator Or
-            - $ref: '#/components/schemas/Logical'
+          $ref: '#/components/schemas/Logical'
         $not:
-          allOf:
-            - title: Logical operator Not
-            - $ref: '#/components/schemas/Logical'
+          $ref: '#/components/schemas/Logical'
     Logical:
       title: Logical operators
       type: array
       items:
-        anyOf: 
+        anyOf:
           - $ref: '#/components/schemas/Logicals'
           - $ref: '#/components/schemas/Params'
     Params:
@@ -5124,19 +5118,19 @@ components:
       properties:
         $eq:
           title: Perform an exact match search on the given value
-          anyOf: 
+          oneOf:
             - type: string
             - type: number
         $text:
           title: Perform a text search on the given value
-          anyOf: 
+          oneOf:
             - type: string
             - type: number
         $in:
           title: Perform a search on an array of values
           type: array
           items: 
-            anyOf:
+            oneOf:
               - type: string
               - type: number
         $gt:

--- a/aylien/v1/news/api-docs.yaml
+++ b/aylien/v1/news/api-docs.yaml
@@ -520,14 +520,22 @@ paths:
         - $ref: "#/components/parameters/notentities_title_text"
         - $ref: "#/components/parameters/entities_title_type"
         - $ref: "#/components/parameters/notentities_title_type"
+        - $ref: "#/components/parameters/entities_title_stock_ticker"
+        - $ref: "#/components/parameters/notentities_title_stock_ticker"
         - $ref: "#/components/parameters/entities_title_links_dbpedia"
         - $ref: "#/components/parameters/notentities_title_links_dbpedia"
+        - $ref: "#/components/parameters/entities_title_links_wikipedia"
+        - $ref: "#/components/parameters/notentities_title_links_wikipedia"
         - $ref: "#/components/parameters/entities_body_text"
         - $ref: "#/components/parameters/notentities_body_text"
         - $ref: "#/components/parameters/entities_body_type"
         - $ref: "#/components/parameters/notentities_body_type"
+        - $ref: "#/components/parameters/entities_body_stock_ticker"
+        - $ref: "#/components/parameters/notentities_body_stock_ticker"
         - $ref: "#/components/parameters/entities_body_links_dbpedia"
         - $ref: "#/components/parameters/notentities_body_links_dbpedia"
+        - $ref: "#/components/parameters/entities_body_links_wikipedia"
+        - $ref: "#/components/parameters/notentities_body_links_wikipedia"
         - $ref: "#/components/parameters/sentiment_title_polarity"
         - $ref: "#/components/parameters/notsentiment_title_polarity"
         - $ref: "#/components/parameters/sentiment_body_polarity"
@@ -1013,14 +1021,22 @@ paths:
       - $ref: "#/components/parameters/notentities_title_text"
       - $ref: "#/components/parameters/entities_title_type"
       - $ref: "#/components/parameters/notentities_title_type"
+      - $ref: "#/components/parameters/entities_title_stock_ticker"
+      - $ref: "#/components/parameters/notentities_title_stock_ticker"
       - $ref: "#/components/parameters/entities_title_links_dbpedia"
       - $ref: "#/components/parameters/notentities_title_links_dbpedia"
+      - $ref: "#/components/parameters/entities_title_links_wikipedia"
+      - $ref: "#/components/parameters/notentities_title_links_wikipedia"
       - $ref: "#/components/parameters/entities_body_text"
       - $ref: "#/components/parameters/notentities_body_text"
       - $ref: "#/components/parameters/entities_body_type"
       - $ref: "#/components/parameters/notentities_body_type"
+      - $ref: "#/components/parameters/entities_body_stock_ticker"
+      - $ref: "#/components/parameters/notentities_body_stock_ticker"
       - $ref: "#/components/parameters/entities_body_links_dbpedia"
       - $ref: "#/components/parameters/notentities_body_links_dbpedia"
+      - $ref: "#/components/parameters/entities_body_links_wikipedia"
+      - $ref: "#/components/parameters/notentities_body_links_wikipedia"
       - $ref: "#/components/parameters/sentiment_title_polarity"
       - $ref: "#/components/parameters/notsentiment_title_polarity"
       - $ref: "#/components/parameters/sentiment_body_polarity"
@@ -1329,14 +1345,22 @@ paths:
         - $ref: "#/components/parameters/notentities_title_text"
         - $ref: "#/components/parameters/entities_title_type"
         - $ref: "#/components/parameters/notentities_title_type"
+        - $ref: "#/components/parameters/entities_title_stock_ticker"
+        - $ref: "#/components/parameters/notentities_title_stock_ticker"
         - $ref: "#/components/parameters/entities_title_links_dbpedia"
         - $ref: "#/components/parameters/notentities_title_links_dbpedia"
+        - $ref: "#/components/parameters/entities_title_links_wikipedia"
+        - $ref: "#/components/parameters/notentities_title_links_wikipedia"
         - $ref: "#/components/parameters/entities_body_text"
         - $ref: "#/components/parameters/notentities_body_text"
         - $ref: "#/components/parameters/entities_body_type"
         - $ref: "#/components/parameters/notentities_body_type"
+        - $ref: "#/components/parameters/entities_body_stock_ticker"
+        - $ref: "#/components/parameters/notentities_body_stock_ticker"
         - $ref: "#/components/parameters/entities_body_links_dbpedia"
         - $ref: "#/components/parameters/notentities_body_links_dbpedia"
+        - $ref: "#/components/parameters/entities_body_links_wikipedia"
+        - $ref: "#/components/parameters/notentities_body_links_wikipedia"
         - $ref: "#/components/parameters/sentiment_title_polarity"
         - $ref: "#/components/parameters/notsentiment_title_polarity"
         - $ref: "#/components/parameters/sentiment_body_polarity"
@@ -2260,14 +2284,22 @@ paths:
         - $ref: "#/components/parameters/notentities_title_text"
         - $ref: "#/components/parameters/entities_title_type"
         - $ref: "#/components/parameters/notentities_title_type"
+        - $ref: "#/components/parameters/entities_title_stock_ticker"
+        - $ref: "#/components/parameters/notentities_title_stock_ticker"
         - $ref: "#/components/parameters/entities_title_links_dbpedia"
         - $ref: "#/components/parameters/notentities_title_links_dbpedia"
+        - $ref: "#/components/parameters/entities_title_links_wikipedia"
+        - $ref: "#/components/parameters/notentities_title_links_wikipedia"
         - $ref: "#/components/parameters/entities_body_text"
         - $ref: "#/components/parameters/notentities_body_text"
         - $ref: "#/components/parameters/entities_body_type"
         - $ref: "#/components/parameters/notentities_body_type"
+        - $ref: "#/components/parameters/entities_body_stock_ticker"
+        - $ref: "#/components/parameters/notentities_body_stock_ticker"
         - $ref: "#/components/parameters/entities_body_links_dbpedia"
         - $ref: "#/components/parameters/notentities_body_links_dbpedia"
+        - $ref: "#/components/parameters/entities_body_links_wikipedia"
+        - $ref: "#/components/parameters/notentities_body_links_wikipedia"
         - $ref: "#/components/parameters/sentiment_title_polarity"
         - $ref: "#/components/parameters/notsentiment_title_polarity"
         - $ref: "#/components/parameters/sentiment_body_polarity"
@@ -2494,14 +2526,22 @@ paths:
         - $ref: "#/components/parameters/notentities_title_text"
         - $ref: "#/components/parameters/entities_title_type"
         - $ref: "#/components/parameters/notentities_title_type"
+        - $ref: "#/components/parameters/entities_title_stock_ticker"
+        - $ref: "#/components/parameters/notentities_title_stock_ticker"
         - $ref: "#/components/parameters/entities_title_links_dbpedia"
         - $ref: "#/components/parameters/notentities_title_links_dbpedia"
+        - $ref: "#/components/parameters/entities_title_links_wikipedia"
+        - $ref: "#/components/parameters/notentities_title_links_wikipedia"
         - $ref: "#/components/parameters/entities_body_text"
         - $ref: "#/components/parameters/notentities_body_text"
         - $ref: "#/components/parameters/entities_body_type"
         - $ref: "#/components/parameters/notentities_body_type"
+        - $ref: "#/components/parameters/entities_body_stock_ticker"
+        - $ref: "#/components/parameters/notentities_body_stock_ticker"
         - $ref: "#/components/parameters/entities_body_links_dbpedia"
         - $ref: "#/components/parameters/notentities_body_links_dbpedia"
+        - $ref: "#/components/parameters/entities_body_links_wikipedia"
+        - $ref: "#/components/parameters/notentities_body_links_wikipedia"
         - $ref: "#/components/parameters/sentiment_title_polarity"
         - $ref: "#/components/parameters/notsentiment_title_polarity"
         - $ref: "#/components/parameters/sentiment_body_polarity"
@@ -2830,6 +2870,20 @@ components:
         nullable: true
         type: array
       style: form
+    entities_body_links_wikipedia:
+      description: >
+        This parameter is used to find stories based on the specified entities
+        wickipedia URL in the body of stories. You can read more about working with
+        entities [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: entities.body.links.wikipedia[]
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
     entities_body_text:
       description: >
         This parameter is used to find stories based on the specified entities
@@ -2858,6 +2912,20 @@ components:
         nullable: true
         type: array
       style: form
+    entities_body_stock_ticker:
+      description: >
+        This parameter is used to find stories based on the specified entities
+        `stock_ticker` in the body of stories. You can read more about working with
+        entities [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: entities.body.stock_ticker[]
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
     entities_title_links_dbpedia:
       description: >
         This parameter is used to find stories based on the specified entities
@@ -2866,6 +2934,20 @@ components:
       explode: true
       in: query
       name: entities.title.links.dbpedia[]
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
+    entities_title_links_wikipedia:
+      description: >
+        This parameter is used to find stories based on the specified entities
+        Wikipedia URL in story titles. You can read more about working with
+        entities [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: entities.title.links.wikipedia[]
       schema:
         items:
           type: string
@@ -2894,6 +2976,20 @@ components:
       explode: true
       in: query
       name: entities.title.type[]
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
+    entities_title_stock_ticker:
+      description: >
+        This parameter is used to find stories based on the specified entities
+        `stock_ticker` in story titles. You can read more about working with entities
+        [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: entities.title.stock_ticker[]
       schema:
         items:
           type: string
@@ -3159,6 +3255,21 @@ components:
         nullable: true
         type: array
       style: form
+    notentities_body_links_wikipedia:
+      description: >
+        This parameter is used to exclude stories based on the specified
+        entities Wikipedia URL in the body of stories. You can read more about
+        working with entities
+        [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: "!entities.body.links.wikipedia[]"
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
     notentities_body_text:
       description: >
         This parameter is used to exclude stories based on the specified
@@ -3189,6 +3300,21 @@ components:
         nullable: true
         type: array
       style: form
+    notentities_body_stock_ticker:
+      description: >
+        This parameter is used to exclude stories based on the specified
+        entities `stock_ticker` in the body of stories. You can read more about working
+        with entities
+        [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: "!entities.body.stock_ticker[]"
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
     notentities_title_links_dbpedia:
       description: >
         This parameter is used to exclude stories based on the specified
@@ -3198,6 +3324,21 @@ components:
       explode: true
       in: query
       name: "!entities.title.links.dbpedia[]"
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
+    notentities_title_links_wikipedia:
+      description: >
+        This parameter is used to exclude stories based on the specified
+        entities Wikipedia URL in story titles. You can read more about working
+        with entities
+        [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: "!entities.title.links.wikipedia[]"
       schema:
         items:
           type: string
@@ -3226,6 +3367,20 @@ components:
       explode: true
       in: query
       name: "!entities.title.type[]"
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
+    notentities_title_stock_ticker:
+      description: >
+        This parameter is used to exclude stories based on the specified
+        entities `stock_ticker` in story titles. You can read more about working with
+        entities [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: "!entities.title.stock_ticker[]"
       schema:
         items:
           type: string
@@ -3994,6 +4149,16 @@ components:
       schema:
         nullable: true
         type: string
+    query:
+      description: >
+        This parameter is used to make an advanced query using $and, $or, $not logical operators
+        and $eq for exact match, $text for a text search and $lt, $gt, $lte, $gte for range queries.
+        value must be a json string.
+      in: query
+      name: query
+      schema:
+        nullable: true
+        type: string
   responses:
     autocompletes:
       content:
@@ -4397,7 +4562,7 @@ components:
             type: string
           type: array
         sentiment:
-          $ref: "#/components/schemas/EntitySentiment"
+          $ref: "#/components/schemas/EntitySentiment"  
       type: object
     EntityLinks:
       properties:
@@ -5118,12 +5283,12 @@ components:
       properties:
         $eq:
           title: Perform an exact match search on the given value
-          oneOf:
+          oneOf: 
             - type: string
             - type: number
         $text:
           title: Perform a text search on the given value
-          oneOf:
+          oneOf: 
             - type: string
             - type: number
         $in:
@@ -5211,4 +5376,3 @@ components:
                     - $not:
                       - type:
                           $eq: Fruit
-

--- a/aylien/v1/news/api-docs.yaml
+++ b/aylien/v1/news/api-docs.yaml
@@ -5323,7 +5323,7 @@ components:
           $ref: '#/components/schemas/Query'
         element:
           $ref: '#/components/schemas/Query'
-        link.wikipedia:
+        links.wikipedia:
           $ref: '#/components/schemas/Query'
         stock_ticker:
           $ref: '#/components/schemas/Query'

--- a/aylien/v1/news/api-docs.yaml
+++ b/aylien/v1/news/api-docs.yaml
@@ -1796,6 +1796,428 @@ paths:
         - app_id: []
         - app_key: []
       summary: List Stories
+    post:
+      tags:
+        - story
+      description: >
+        The stories endpoint is used to return stories based on the json query you
+        set in your request body. The News API crawler gathers articles in near
+        real-time and stores information about them, or metadata. Below you can
+        see all of the query parameters, and JSON schema for the body, which you
+        can use to narrow down your query.
+      operationId: advancedListStories
+      parameters:
+        - $ref: "#/components/securitySchemes/app_id"
+        - $ref: "#/components/securitySchemes/app_key"
+        - $ref: "#/components/parameters/published_at_start"
+        - $ref: "#/components/parameters/published_at_end"
+        - $ref: "#/components/parameters/return"
+        - description: >
+            This parameter is used for changing the order column of the results.
+            You can read about sorting results
+            [here](https://newsapi.aylien.com/docs/sorting-results).
+          in: query
+          name: sort_by
+          schema:
+            default: published_at
+            enum:
+              - relevance
+              - recency
+              - hotness
+              - published_at
+              - social_shares_count
+              - social_shares_count.facebook
+              - social_shares_count.linkedin
+              - social_shares_count.google_plus
+              - social_shares_count.reddit
+              - media.images.count
+              - media.videos.count
+              - source.links_in_count
+              - source.rankings.alexa.rank
+              - source.rankings.alexa.rank.AF
+              - source.rankings.alexa.rank.AX
+              - source.rankings.alexa.rank.AL
+              - source.rankings.alexa.rank.DZ
+              - source.rankings.alexa.rank.AS
+              - source.rankings.alexa.rank.AD
+              - source.rankings.alexa.rank.AO
+              - source.rankings.alexa.rank.AI
+              - source.rankings.alexa.rank.AQ
+              - source.rankings.alexa.rank.AG
+              - source.rankings.alexa.rank.AR
+              - source.rankings.alexa.rank.AM
+              - source.rankings.alexa.rank.AW
+              - source.rankings.alexa.rank.AU
+              - source.rankings.alexa.rank.AT
+              - source.rankings.alexa.rank.AZ
+              - source.rankings.alexa.rank.BS
+              - source.rankings.alexa.rank.BH
+              - source.rankings.alexa.rank.BD
+              - source.rankings.alexa.rank.BB
+              - source.rankings.alexa.rank.BY
+              - source.rankings.alexa.rank.BE
+              - source.rankings.alexa.rank.BZ
+              - source.rankings.alexa.rank.BJ
+              - source.rankings.alexa.rank.BM
+              - source.rankings.alexa.rank.BT
+              - source.rankings.alexa.rank.BO
+              - source.rankings.alexa.rank.BQ
+              - source.rankings.alexa.rank.BA
+              - source.rankings.alexa.rank.BW
+              - source.rankings.alexa.rank.BV
+              - source.rankings.alexa.rank.BR
+              - source.rankings.alexa.rank.IO
+              - source.rankings.alexa.rank.BN
+              - source.rankings.alexa.rank.BG
+              - source.rankings.alexa.rank.BF
+              - source.rankings.alexa.rank.BI
+              - source.rankings.alexa.rank.KH
+              - source.rankings.alexa.rank.CM
+              - source.rankings.alexa.rank.CA
+              - source.rankings.alexa.rank.CV
+              - source.rankings.alexa.rank.KY
+              - source.rankings.alexa.rank.CF
+              - source.rankings.alexa.rank.TD
+              - source.rankings.alexa.rank.CL
+              - source.rankings.alexa.rank.CN
+              - source.rankings.alexa.rank.CX
+              - source.rankings.alexa.rank.CC
+              - source.rankings.alexa.rank.CO
+              - source.rankings.alexa.rank.KM
+              - source.rankings.alexa.rank.CG
+              - source.rankings.alexa.rank.CD
+              - source.rankings.alexa.rank.CK
+              - source.rankings.alexa.rank.CR
+              - source.rankings.alexa.rank.CI
+              - source.rankings.alexa.rank.HR
+              - source.rankings.alexa.rank.CU
+              - source.rankings.alexa.rank.CW
+              - source.rankings.alexa.rank.CY
+              - source.rankings.alexa.rank.CZ
+              - source.rankings.alexa.rank.DK
+              - source.rankings.alexa.rank.DJ
+              - source.rankings.alexa.rank.DM
+              - source.rankings.alexa.rank.DO
+              - source.rankings.alexa.rank.EC
+              - source.rankings.alexa.rank.EG
+              - source.rankings.alexa.rank.SV
+              - source.rankings.alexa.rank.GQ
+              - source.rankings.alexa.rank.ER
+              - source.rankings.alexa.rank.EE
+              - source.rankings.alexa.rank.ET
+              - source.rankings.alexa.rank.FK
+              - source.rankings.alexa.rank.FO
+              - source.rankings.alexa.rank.FJ
+              - source.rankings.alexa.rank.FI
+              - source.rankings.alexa.rank.FR
+              - source.rankings.alexa.rank.GF
+              - source.rankings.alexa.rank.PF
+              - source.rankings.alexa.rank.TF
+              - source.rankings.alexa.rank.GA
+              - source.rankings.alexa.rank.GM
+              - source.rankings.alexa.rank.GE
+              - source.rankings.alexa.rank.DE
+              - source.rankings.alexa.rank.GH
+              - source.rankings.alexa.rank.GI
+              - source.rankings.alexa.rank.GR
+              - source.rankings.alexa.rank.GL
+              - source.rankings.alexa.rank.GD
+              - source.rankings.alexa.rank.GP
+              - source.rankings.alexa.rank.GU
+              - source.rankings.alexa.rank.GT
+              - source.rankings.alexa.rank.GG
+              - source.rankings.alexa.rank.GN
+              - source.rankings.alexa.rank.GW
+              - source.rankings.alexa.rank.GY
+              - source.rankings.alexa.rank.HT
+              - source.rankings.alexa.rank.HM
+              - source.rankings.alexa.rank.VA
+              - source.rankings.alexa.rank.HN
+              - source.rankings.alexa.rank.HK
+              - source.rankings.alexa.rank.HU
+              - source.rankings.alexa.rank.IS
+              - source.rankings.alexa.rank.IN
+              - source.rankings.alexa.rank.ID
+              - source.rankings.alexa.rank.IR
+              - source.rankings.alexa.rank.IQ
+              - source.rankings.alexa.rank.IE
+              - source.rankings.alexa.rank.IM
+              - source.rankings.alexa.rank.IL
+              - source.rankings.alexa.rank.IT
+              - source.rankings.alexa.rank.JM
+              - source.rankings.alexa.rank.JP
+              - source.rankings.alexa.rank.JE
+              - source.rankings.alexa.rank.JO
+              - source.rankings.alexa.rank.KZ
+              - source.rankings.alexa.rank.KE
+              - source.rankings.alexa.rank.KI
+              - source.rankings.alexa.rank.KP
+              - source.rankings.alexa.rank.KR
+              - source.rankings.alexa.rank.KW
+              - source.rankings.alexa.rank.KG
+              - source.rankings.alexa.rank.LA
+              - source.rankings.alexa.rank.LV
+              - source.rankings.alexa.rank.LB
+              - source.rankings.alexa.rank.LS
+              - source.rankings.alexa.rank.LR
+              - source.rankings.alexa.rank.LY
+              - source.rankings.alexa.rank.LI
+              - source.rankings.alexa.rank.LT
+              - source.rankings.alexa.rank.LU
+              - source.rankings.alexa.rank.MO
+              - source.rankings.alexa.rank.MK
+              - source.rankings.alexa.rank.MG
+              - source.rankings.alexa.rank.MW
+              - source.rankings.alexa.rank.MY
+              - source.rankings.alexa.rank.MV
+              - source.rankings.alexa.rank.ML
+              - source.rankings.alexa.rank.MT
+              - source.rankings.alexa.rank.MH
+              - source.rankings.alexa.rank.MQ
+              - source.rankings.alexa.rank.MR
+              - source.rankings.alexa.rank.MU
+              - source.rankings.alexa.rank.YT
+              - source.rankings.alexa.rank.MX
+              - source.rankings.alexa.rank.FM
+              - source.rankings.alexa.rank.MD
+              - source.rankings.alexa.rank.MC
+              - source.rankings.alexa.rank.MN
+              - source.rankings.alexa.rank.ME
+              - source.rankings.alexa.rank.MS
+              - source.rankings.alexa.rank.MA
+              - source.rankings.alexa.rank.MZ
+              - source.rankings.alexa.rank.MM
+              - source.rankings.alexa.rank.NA
+              - source.rankings.alexa.rank.NR
+              - source.rankings.alexa.rank.NP
+              - source.rankings.alexa.rank.NL
+              - source.rankings.alexa.rank.NC
+              - source.rankings.alexa.rank.NZ
+              - source.rankings.alexa.rank.NI
+              - source.rankings.alexa.rank.NE
+              - source.rankings.alexa.rank.NG
+              - source.rankings.alexa.rank.NU
+              - source.rankings.alexa.rank.NF
+              - source.rankings.alexa.rank.MP
+              - source.rankings.alexa.rank.NO
+              - source.rankings.alexa.rank.OM
+              - source.rankings.alexa.rank.PK
+              - source.rankings.alexa.rank.PW
+              - source.rankings.alexa.rank.PS
+              - source.rankings.alexa.rank.PA
+              - source.rankings.alexa.rank.PG
+              - source.rankings.alexa.rank.PY
+              - source.rankings.alexa.rank.PE
+              - source.rankings.alexa.rank.PH
+              - source.rankings.alexa.rank.PN
+              - source.rankings.alexa.rank.PL
+              - source.rankings.alexa.rank.PT
+              - source.rankings.alexa.rank.PR
+              - source.rankings.alexa.rank.QA
+              - source.rankings.alexa.rank.RE
+              - source.rankings.alexa.rank.RO
+              - source.rankings.alexa.rank.RU
+              - source.rankings.alexa.rank.RW
+              - source.rankings.alexa.rank.BL
+              - source.rankings.alexa.rank.SH
+              - source.rankings.alexa.rank.KN
+              - source.rankings.alexa.rank.LC
+              - source.rankings.alexa.rank.MF
+              - source.rankings.alexa.rank.PM
+              - source.rankings.alexa.rank.VC
+              - source.rankings.alexa.rank.WS
+              - source.rankings.alexa.rank.SM
+              - source.rankings.alexa.rank.ST
+              - source.rankings.alexa.rank.SA
+              - source.rankings.alexa.rank.SN
+              - source.rankings.alexa.rank.RS
+              - source.rankings.alexa.rank.SC
+              - source.rankings.alexa.rank.SL
+              - source.rankings.alexa.rank.SG
+              - source.rankings.alexa.rank.SX
+              - source.rankings.alexa.rank.SK
+              - source.rankings.alexa.rank.SI
+              - source.rankings.alexa.rank.SB
+              - source.rankings.alexa.rank.SO
+              - source.rankings.alexa.rank.ZA
+              - source.rankings.alexa.rank.GS
+              - source.rankings.alexa.rank.SS
+              - source.rankings.alexa.rank.ES
+              - source.rankings.alexa.rank.LK
+              - source.rankings.alexa.rank.SD
+              - source.rankings.alexa.rank.SR
+              - source.rankings.alexa.rank.SJ
+              - source.rankings.alexa.rank.SZ
+              - source.rankings.alexa.rank.SE
+              - source.rankings.alexa.rank.CH
+              - source.rankings.alexa.rank.SY
+              - source.rankings.alexa.rank.TW
+              - source.rankings.alexa.rank.TJ
+              - source.rankings.alexa.rank.TZ
+              - source.rankings.alexa.rank.TH
+              - source.rankings.alexa.rank.TL
+              - source.rankings.alexa.rank.TG
+              - source.rankings.alexa.rank.TK
+              - source.rankings.alexa.rank.TO
+              - source.rankings.alexa.rank.TT
+              - source.rankings.alexa.rank.TN
+              - source.rankings.alexa.rank.TR
+              - source.rankings.alexa.rank.TM
+              - source.rankings.alexa.rank.TC
+              - source.rankings.alexa.rank.TV
+              - source.rankings.alexa.rank.UG
+              - source.rankings.alexa.rank.UA
+              - source.rankings.alexa.rank.AE
+              - source.rankings.alexa.rank.GB
+              - source.rankings.alexa.rank.US
+              - source.rankings.alexa.rank.UM
+              - source.rankings.alexa.rank.UY
+              - source.rankings.alexa.rank.UZ
+              - source.rankings.alexa.rank.VU
+              - source.rankings.alexa.rank.VE
+              - source.rankings.alexa.rank.VN
+              - source.rankings.alexa.rank.VG
+              - source.rankings.alexa.rank.VI
+              - source.rankings.alexa.rank.WF
+              - source.rankings.alexa.rank.EH
+              - source.rankings.alexa.rank.YE
+              - source.rankings.alexa.rank.ZM
+              - source.rankings.alexa.rank.ZW
+            nullable: true
+            type: string
+        - description: >
+            This parameter is used for changing the order direction of the
+            result. You can read about sorting results
+            [here](https://newsapi.aylien.com/docs/sorting-results).
+          in: query
+          name: sort_direction
+          schema:
+            default: desc
+            enum:
+              - asc
+              - desc
+            nullable: true
+            type: string
+        - description: >
+            This parameter is used for finding a specific page. You can read
+            more about pagination of results
+            [here](https://newsapi.aylien.com/docs/pagination-of-results).
+          in: query
+          name: cursor
+          schema:
+            default: "*"
+            nullable: true
+            type: string
+        - description: >
+            This parameter is used for specifying number of items in each page
+            You can read more about pagination of results
+            [here](https://newsapi.aylien.com/docs/pagination-of-results)
+          in: query
+          name: per_page
+          schema:
+            default: 10
+            format: int32
+            maximum: 100
+            minimum: 1
+            nullable: true
+            type: integer
+      requestBody:
+        $ref: '#/components/requestBodies/StoriesBody'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Stories"
+            text/xml:
+              schema:
+                $ref: "#/components/schemas/Stories"
+          description: An object including an array of stories
+          headers:
+            X-RateLimit-Limit:
+              description: The number of allowed requests in the current period.
+              schema:
+                format: int32
+                type: integer
+            X-RateLimit-Remaining:
+              description: The number of remaining requests in the current period.
+              schema:
+                format: int32
+                type: integer
+            X-RateLimit-Reset:
+              description: >
+                The remaining window before the rate limit resets in UTC [epoch
+                seconds](https://en.wikipedia.org/wiki/Unix_time).
+              schema:
+                format: int64
+                type: integer
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Errors"
+            text/xml:
+              schema:
+                $ref: "#/components/schemas/Errors"
+          description: Unauthorized
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Errors"
+            text/xml:
+              schema:
+                $ref: "#/components/schemas/Errors"
+          description: Not Found
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Errors"
+            text/xml:
+              schema:
+                $ref: "#/components/schemas/Errors"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Errors"
+            text/xml:
+              schema:
+                $ref: "#/components/schemas/Errors"
+          description: Too Many Requests
+          headers:
+            X-RateLimit-Limit:
+              description: The number of allowed requests in the current period.
+              schema:
+                format: int32
+                type: integer
+            X-RateLimit-Remaining:
+              description: The number of remaining requests in the current period.
+              schema:
+                format: int32
+                type: integer
+            X-RateLimit-Reset:
+              description: >
+                The remaining window before the rate limit resets in UTC [epoch
+                seconds](https://en.wikipedia.org/wiki/Unix_time).
+              schema:
+                format: int64
+                type: integer
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Errors"
+            text/xml:
+              schema:
+                $ref: "#/components/schemas/Errors"
+          description: Internal Server Error
+      security:
+        - app_id: []
+        - app_key: []
+      summary: List Stories
   /time_series:
     get:
       tags:
@@ -4555,6 +4977,199 @@ components:
           description: The detailed description of the warning.
           type: string
       type: object
+    Logicals: 
+      title: One of the logical operators such as $and, $or, $not
+      type: object
+      properties:
+        $and:
+          allOf:
+            - title: Logical operator And
+            - $ref: '#/components/schemas/Logical'
+        $or:
+          allOf:
+            - title: Logical operator Or
+            - $ref: '#/components/schemas/Logical'
+        $not:
+          allOf:
+            - title: Logical operator Not
+            - $ref: '#/components/schemas/Logical'
+    Logical:
+      title: Logical operators
+      type: array
+      items:
+        anyOf: 
+          - $ref: '#/components/schemas/Logicals'
+          - $ref: '#/components/schemas/Params'
+    Params:
+      title: Parameter defines the search query on a field
+      type: object
+      properties:
+        author.id:
+          $ref: '#/components/schemas/Parameter'
+        author.name:
+          $ref: '#/components/schemas/Parameter'
+        body:
+          $ref: '#/components/schemas/Parameter'
+        categories.confident:
+          $ref: '#/components/schemas/Parameter'
+        categories.id:
+          $ref: '#/components/schemas/Parameter'
+        categories.level:
+          $ref: '#/components/schemas/Parameter'
+        categories.taxonomy:
+          $ref: '#/components/schemas/Parameter'
+        clusters:
+          $ref: '#/components/schemas/Parameter'
+        links.permalink:
+          $ref: '#/components/schemas/Parameter'
+        entities.body.links.dbpedia:
+          $ref: '#/components/schemas/Parameter'
+        entities.body.text:
+          $ref: '#/components/schemas/Parameter'
+        entities.body.type:
+          $ref: '#/components/schemas/Parameter'
+        entities.title.links.dbpedia:
+          $ref: '#/components/schemas/Parameter'
+        entities.title.text:
+          $ref: '#/components/schemas/Parameter'
+        entities.title.type:
+          $ref: '#/components/schemas/Parameter'
+        id:
+          $ref: '#/components/schemas/Parameter'
+        language:
+          $ref: '#/components/schemas/Parameter'
+        media.images.content.length.max:
+          $ref: '#/components/schemas/Parameter'
+        media.images.content.length.min:
+          $ref: '#/components/schemas/Parameter'
+        media.images.count.max:
+          $ref: '#/components/schemas/Parameter'
+        media.images.count.min:
+          $ref: '#/components/schemas/Parameter'
+        media.images.format:
+          $ref: '#/components/schemas/Parameter'
+        media.images.height.max:
+          $ref: '#/components/schemas/Parameter'
+        media.images.height.min:
+          $ref: '#/components/schemas/Parameter'
+        media.images.width.max:
+          $ref: '#/components/schemas/Parameter'
+        media.images.width.min:
+          $ref: '#/components/schemas/Parameter'
+        media.videos.count.max:
+          $ref: '#/components/schemas/Parameter'
+        media.videos.count.min:
+          $ref: '#/components/schemas/Parameter'
+        sentiment.body.polarity:
+          $ref: '#/components/schemas/Parameter'
+        sentiment.title.polarity:
+          $ref: '#/components/schemas/Parameter'
+        social.shares.count.facebook.max:
+          $ref: '#/components/schemas/Parameter'
+        social.shares.count.facebook.min:
+          $ref: '#/components/schemas/Parameter'
+        social.shares.count.reddit.max:
+          $ref: '#/components/schemas/Parameter'
+        social.shares.count.reddit.min:
+          $ref: '#/components/schemas/Parameter'
+        source.domain:
+          $ref: '#/components/schemas/Parameter'
+        source.id:
+          $ref: '#/components/schemas/Parameter'
+        source.links.in.count.max:
+          $ref: '#/components/schemas/Parameter'
+        source.links.in.count.min:
+          $ref: '#/components/schemas/Parameter'
+        source.locations.city:
+          $ref: '#/components/schemas/Parameter'
+        source.locations.country:
+          $ref: '#/components/schemas/Parameter'
+        source.locations.state:
+          $ref: '#/components/schemas/Parameter'
+        source.rankings.alexa.country:
+          $ref: '#/components/schemas/Parameter'
+        source.rankings.alexa.rank.max:
+          $ref: '#/components/schemas/Parameter'
+        source.rankings.alexa.rank.min:
+          $ref: '#/components/schemas/Parameter'
+        source.scopes.city:
+          $ref: '#/components/schemas/Parameter'
+        source.scopes.country:
+          $ref: '#/components/schemas/Parameter'
+        source.scopes.level:
+          $ref: '#/components/schemas/Parameter'
+        source.scopes.state:
+          $ref: '#/components/schemas/Parameter'
+        story_url:
+          $ref: '#/components/schemas/Parameter'
+        story_language:
+          $ref: '#/components/schemas/Parameter'
+        text:
+          $ref: '#/components/schemas/Parameter'
+        title:
+          $ref: '#/components/schemas/Parameter'
+        translations.en.body:
+          $ref: '#/components/schemas/Parameter'
+        translations.en.text:
+          $ref: '#/components/schemas/Parameter'
+        translations.en.title:
+          $ref: '#/components/schemas/Parameter'
+        entity:
+          oneOf:
+            - $ref: '#/components/schemas/NestedEntity'
+            - $ref: '#/components/schemas/Logicals'
+    Parameter:
+      title: Parameter defines the search query on a field
+      type: object
+      properties:
+        $eq:
+          title: Perform an exact match search on the given value
+          anyOf: 
+            - type: string
+            - type: number
+        $text:
+          title: Perform a text search on the given value
+          anyOf: 
+            - type: string
+            - type: number
+        $in:
+          title: Perform a search on an array of values
+          type: array
+          items: 
+            anyOf:
+              - type: string
+              - type: number
+        $gt:
+          title: Perform a greater than search on the given value
+          type: number
+        $gte:
+          title: Perform a greater than equal search on the given value
+          type: number
+        $lt:
+          title: Perform a less than search on the given value
+          type: number
+        $lte:
+          title: Perform a less than equal search on the given value
+          type: number
+        $boost:
+          title: Gives a weight to the field on performing the query
+          type: number        
+    NestedEntity:
+      type: object
+      title: To perform a nested search on entities use this.
+      properties:
+        name:
+          $ref: '#/components/schemas/Parameter'
+        sentiment:
+          $ref: '#/components/schemas/Parameter'
+        element:
+          $ref: '#/components/schemas/Parameter'
+        link.wikipedia:
+          $ref: '#/components/schemas/Parameter'
+        stock_ticker:
+          $ref: '#/components/schemas/Parameter'
+        type:
+          $ref: '#/components/schemas/Parameter'
   securitySchemes:
     app_id:
       x-auth-id-alias: true
@@ -4574,3 +5189,32 @@ components:
       in: header
       name: X-AYLIEN-NewsAPI-Application-Key
       type: apiKey
+  requestBodies:
+    StoriesBody:
+      required: true
+      description: >
+        /stories body schema to perform an advanced search with logical operators
+        and nested objects.
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/Logicals'
+              - $ref: '#/components/schemas/Params'
+          example:
+            $and:
+              - $or:
+                - body:
+                    $text: Tim Cook
+                - social.shares.count.reddit.max:
+                    $gte: 5000
+                    $boost: 5
+              - entity:
+                  $and:
+                    - name:
+                        $text: Apple
+                        $boost: 2
+                    - $not:
+                      - type:
+                          $eq: Fruit
+

--- a/aylien/v1/news/api-docs.yaml
+++ b/aylien/v1/news/api-docs.yaml
@@ -4993,127 +4993,127 @@ components:
       items:
         anyOf:
           - $ref: '#/components/schemas/Logicals'
-          - $ref: '#/components/schemas/Params'
-    Params:
-      title: Parameter defines the search query on a field
+          - $ref: '#/components/schemas/Parameter'
+    Parameter:
+      title: Query defines the search query on a field
       type: object
       properties:
         author.id:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         author.name:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         body:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         categories.confident:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         categories.id:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         categories.level:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         categories.taxonomy:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         clusters:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         links.permalink:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         entities.body.links.dbpedia:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         entities.body.text:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         entities.body.type:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         entities.title.links.dbpedia:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         entities.title.text:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         entities.title.type:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         id:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         language:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.images.content.length.max:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.images.content.length.min:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.images.count.max:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.images.count.min:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.images.format:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.images.height.max:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.images.height.min:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.images.width.max:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.images.width.min:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.videos.count.max:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.videos.count.min:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         sentiment.body.polarity:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         sentiment.title.polarity:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         social.shares.count.facebook.max:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         social.shares.count.facebook.min:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         social.shares.count.reddit.max:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         social.shares.count.reddit.min:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.domain:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.id:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.links.in.count.max:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.links.in.count.min:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.locations.city:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.locations.country:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.locations.state:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.rankings.alexa.country:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.rankings.alexa.rank.max:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.rankings.alexa.rank.min:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.scopes.city:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.scopes.country:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.scopes.level:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.scopes.state:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         story_url:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         story_language:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         text:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         title:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         translations.en.body:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         translations.en.text:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         translations.en.title:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         entity:
           oneOf:
             - $ref: '#/components/schemas/NestedEntity'
             - $ref: '#/components/schemas/Logicals'
-    Parameter:
-      title: Parameter defines the search query on a field
+    Query:
+      title: Query defines the search query on a field
       type: object
       properties:
         $eq:
@@ -5153,17 +5153,17 @@ components:
       title: To perform a nested search on entities use this.
       properties:
         name:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         sentiment:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         element:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         link.wikipedia:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         stock_ticker:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         type:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
   securitySchemes:
     app_id:
       x-auth-id-alias: true
@@ -5194,7 +5194,7 @@ components:
           schema:
             oneOf:
               - $ref: '#/components/schemas/Logicals'
-              - $ref: '#/components/schemas/Params'
+              - $ref: '#/components/schemas/Parameter'
           example:
             $and:
               - $or:

--- a/aylien/v1/news/api.yaml
+++ b/aylien/v1/news/api.yaml
@@ -1783,6 +1783,512 @@ paths:
         - app_id: []
         - app_key: []
       summary: List Stories
+    post:
+      tags:
+        - story
+      description: >
+        The stories endpoint is used to return stories based on the json query you
+        set in your request body. The News API crawler gathers articles in near
+        real-time and stores information about them, or metadata. Below you can
+        see all of the query parameters, and JSON schema for the body, which you
+        can use to narrow down your query.
+      operationId: listStories
+      parameters:
+        - $ref: "#/components/parameters/id"
+        - $ref: "#/components/parameters/notid"
+        - $ref: "#/components/parameters/title"
+        - $ref: "#/components/parameters/body"
+        - $ref: "#/components/parameters/text"
+        - $ref: "#/components/parameters/translations_en_title"
+        - $ref: "#/components/parameters/translations_en_body"
+        - $ref: "#/components/parameters/translations_en_text"
+        - $ref: "#/components/parameters/language"
+        - $ref: "#/components/parameters/notlanguage"
+        - $ref: "#/components/parameters/links_permalink"
+        - $ref: "#/components/parameters/notlinks_permalink"
+        - $ref: "#/components/parameters/published_at_start"
+        - $ref: "#/components/parameters/published_at_end"
+        - $ref: "#/components/parameters/categories_taxonomy"
+        - $ref: "#/components/parameters/categories_confident"
+        - $ref: "#/components/parameters/categories_id"
+        - $ref: "#/components/parameters/notcategories_id"
+        - $ref: "#/components/parameters/categories_label"
+        - $ref: "#/components/parameters/notcategories_label"
+        - $ref: "#/components/parameters/categories_level"
+        - $ref: "#/components/parameters/notcategories_level"
+        - $ref: "#/components/parameters/entities_title_text"
+        - $ref: "#/components/parameters/notentities_title_text"
+        - $ref: "#/components/parameters/entities_title_type"
+        - $ref: "#/components/parameters/notentities_title_type"
+        - $ref: "#/components/parameters/entities_title_links_dbpedia"
+        - $ref: "#/components/parameters/notentities_title_links_dbpedia"
+        - $ref: "#/components/parameters/entities_body_text"
+        - $ref: "#/components/parameters/notentities_body_text"
+        - $ref: "#/components/parameters/entities_body_type"
+        - $ref: "#/components/parameters/notentities_body_type"
+        - $ref: "#/components/parameters/entities_body_links_dbpedia"
+        - $ref: "#/components/parameters/notentities_body_links_dbpedia"
+        - $ref: "#/components/parameters/sentiment_title_polarity"
+        - $ref: "#/components/parameters/notsentiment_title_polarity"
+        - $ref: "#/components/parameters/sentiment_body_polarity"
+        - $ref: "#/components/parameters/notsentiment_body_polarity"
+        - $ref: "#/components/parameters/media_images_count_min"
+        - $ref: "#/components/parameters/media_images_count_max"
+        - $ref: "#/components/parameters/media_images_width_min"
+        - $ref: "#/components/parameters/media_images_width_max"
+        - $ref: "#/components/parameters/media_images_height_min"
+        - $ref: "#/components/parameters/media_images_height_max"
+        - $ref: "#/components/parameters/media_images_content_length_min"
+        - $ref: "#/components/parameters/media_images_content_length_max"
+        - $ref: "#/components/parameters/media_images_format"
+        - $ref: "#/components/parameters/notmedia_images_format"
+        - $ref: "#/components/parameters/media_videos_count_min"
+        - $ref: "#/components/parameters/media_videos_count_max"
+        - $ref: "#/components/parameters/author_id"
+        - $ref: "#/components/parameters/notauthor_id"
+        - $ref: "#/components/parameters/author_name"
+        - $ref: "#/components/parameters/notauthor_name"
+        - $ref: "#/components/parameters/source_id"
+        - $ref: "#/components/parameters/notsource_id"
+        - $ref: "#/components/parameters/source_name"
+        - $ref: "#/components/parameters/notsource_name"
+        - $ref: "#/components/parameters/source_domain"
+        - $ref: "#/components/parameters/notsource_domain"
+        - $ref: "#/components/parameters/source_locations_country"
+        - $ref: "#/components/parameters/notsource_locations_country"
+        - $ref: "#/components/parameters/source_locations_state"
+        - $ref: "#/components/parameters/notsource_locations_state"
+        - $ref: "#/components/parameters/source_locations_city"
+        - $ref: "#/components/parameters/notsource_locations_city"
+        - $ref: "#/components/parameters/source_scopes_country"
+        - $ref: "#/components/parameters/notsource_scopes_country"
+        - $ref: "#/components/parameters/source_scopes_state"
+        - $ref: "#/components/parameters/notsource_scopes_state"
+        - $ref: "#/components/parameters/source_scopes_city"
+        - $ref: "#/components/parameters/notsource_scopes_city"
+        - $ref: "#/components/parameters/source_scopes_level"
+        - $ref: "#/components/parameters/notsource_scopes_level"
+        - $ref: "#/components/parameters/source_links_in_count_min"
+        - $ref: "#/components/parameters/source_links_in_count_max"
+        - $ref: "#/components/parameters/source_rankings_alexa_rank_min"
+        - $ref: "#/components/parameters/source_rankings_alexa_rank_max"
+        - $ref: "#/components/parameters/source_rankings_alexa_country"
+        - $ref: "#/components/parameters/social_shares_count_facebook_min"
+        - $ref: "#/components/parameters/social_shares_count_facebook_max"
+        - $ref: "#/components/parameters/social_shares_count_google_plus_min"
+        - $ref: "#/components/parameters/social_shares_count_google_plus_max"
+        - $ref: "#/components/parameters/social_shares_count_linkedin_min"
+        - $ref: "#/components/parameters/social_shares_count_linkedin_max"
+        - $ref: "#/components/parameters/social_shares_count_reddit_min"
+        - $ref: "#/components/parameters/social_shares_count_reddit_max"
+        - $ref: "#/components/parameters/clusters"
+        - $ref: "#/components/parameters/return"
+        - description: >
+            This parameter is used for changing the order column of the results.
+            You can read about sorting results
+            [here](https://newsapi.aylien.com/docs/sorting-results).
+          in: query
+          name: sort_by
+          schema:
+            default: published_at
+            enum:
+              - relevance
+              - recency
+              - hotness
+              - published_at
+              - social_shares_count
+              - social_shares_count.facebook
+              - social_shares_count.linkedin
+              - social_shares_count.google_plus
+              - social_shares_count.reddit
+              - media.images.count
+              - media.videos.count
+              - source.links_in_count
+              - source.rankings.alexa.rank
+              - source.rankings.alexa.rank.AF
+              - source.rankings.alexa.rank.AX
+              - source.rankings.alexa.rank.AL
+              - source.rankings.alexa.rank.DZ
+              - source.rankings.alexa.rank.AS
+              - source.rankings.alexa.rank.AD
+              - source.rankings.alexa.rank.AO
+              - source.rankings.alexa.rank.AI
+              - source.rankings.alexa.rank.AQ
+              - source.rankings.alexa.rank.AG
+              - source.rankings.alexa.rank.AR
+              - source.rankings.alexa.rank.AM
+              - source.rankings.alexa.rank.AW
+              - source.rankings.alexa.rank.AU
+              - source.rankings.alexa.rank.AT
+              - source.rankings.alexa.rank.AZ
+              - source.rankings.alexa.rank.BS
+              - source.rankings.alexa.rank.BH
+              - source.rankings.alexa.rank.BD
+              - source.rankings.alexa.rank.BB
+              - source.rankings.alexa.rank.BY
+              - source.rankings.alexa.rank.BE
+              - source.rankings.alexa.rank.BZ
+              - source.rankings.alexa.rank.BJ
+              - source.rankings.alexa.rank.BM
+              - source.rankings.alexa.rank.BT
+              - source.rankings.alexa.rank.BO
+              - source.rankings.alexa.rank.BQ
+              - source.rankings.alexa.rank.BA
+              - source.rankings.alexa.rank.BW
+              - source.rankings.alexa.rank.BV
+              - source.rankings.alexa.rank.BR
+              - source.rankings.alexa.rank.IO
+              - source.rankings.alexa.rank.BN
+              - source.rankings.alexa.rank.BG
+              - source.rankings.alexa.rank.BF
+              - source.rankings.alexa.rank.BI
+              - source.rankings.alexa.rank.KH
+              - source.rankings.alexa.rank.CM
+              - source.rankings.alexa.rank.CA
+              - source.rankings.alexa.rank.CV
+              - source.rankings.alexa.rank.KY
+              - source.rankings.alexa.rank.CF
+              - source.rankings.alexa.rank.TD
+              - source.rankings.alexa.rank.CL
+              - source.rankings.alexa.rank.CN
+              - source.rankings.alexa.rank.CX
+              - source.rankings.alexa.rank.CC
+              - source.rankings.alexa.rank.CO
+              - source.rankings.alexa.rank.KM
+              - source.rankings.alexa.rank.CG
+              - source.rankings.alexa.rank.CD
+              - source.rankings.alexa.rank.CK
+              - source.rankings.alexa.rank.CR
+              - source.rankings.alexa.rank.CI
+              - source.rankings.alexa.rank.HR
+              - source.rankings.alexa.rank.CU
+              - source.rankings.alexa.rank.CW
+              - source.rankings.alexa.rank.CY
+              - source.rankings.alexa.rank.CZ
+              - source.rankings.alexa.rank.DK
+              - source.rankings.alexa.rank.DJ
+              - source.rankings.alexa.rank.DM
+              - source.rankings.alexa.rank.DO
+              - source.rankings.alexa.rank.EC
+              - source.rankings.alexa.rank.EG
+              - source.rankings.alexa.rank.SV
+              - source.rankings.alexa.rank.GQ
+              - source.rankings.alexa.rank.ER
+              - source.rankings.alexa.rank.EE
+              - source.rankings.alexa.rank.ET
+              - source.rankings.alexa.rank.FK
+              - source.rankings.alexa.rank.FO
+              - source.rankings.alexa.rank.FJ
+              - source.rankings.alexa.rank.FI
+              - source.rankings.alexa.rank.FR
+              - source.rankings.alexa.rank.GF
+              - source.rankings.alexa.rank.PF
+              - source.rankings.alexa.rank.TF
+              - source.rankings.alexa.rank.GA
+              - source.rankings.alexa.rank.GM
+              - source.rankings.alexa.rank.GE
+              - source.rankings.alexa.rank.DE
+              - source.rankings.alexa.rank.GH
+              - source.rankings.alexa.rank.GI
+              - source.rankings.alexa.rank.GR
+              - source.rankings.alexa.rank.GL
+              - source.rankings.alexa.rank.GD
+              - source.rankings.alexa.rank.GP
+              - source.rankings.alexa.rank.GU
+              - source.rankings.alexa.rank.GT
+              - source.rankings.alexa.rank.GG
+              - source.rankings.alexa.rank.GN
+              - source.rankings.alexa.rank.GW
+              - source.rankings.alexa.rank.GY
+              - source.rankings.alexa.rank.HT
+              - source.rankings.alexa.rank.HM
+              - source.rankings.alexa.rank.VA
+              - source.rankings.alexa.rank.HN
+              - source.rankings.alexa.rank.HK
+              - source.rankings.alexa.rank.HU
+              - source.rankings.alexa.rank.IS
+              - source.rankings.alexa.rank.IN
+              - source.rankings.alexa.rank.ID
+              - source.rankings.alexa.rank.IR
+              - source.rankings.alexa.rank.IQ
+              - source.rankings.alexa.rank.IE
+              - source.rankings.alexa.rank.IM
+              - source.rankings.alexa.rank.IL
+              - source.rankings.alexa.rank.IT
+              - source.rankings.alexa.rank.JM
+              - source.rankings.alexa.rank.JP
+              - source.rankings.alexa.rank.JE
+              - source.rankings.alexa.rank.JO
+              - source.rankings.alexa.rank.KZ
+              - source.rankings.alexa.rank.KE
+              - source.rankings.alexa.rank.KI
+              - source.rankings.alexa.rank.KP
+              - source.rankings.alexa.rank.KR
+              - source.rankings.alexa.rank.KW
+              - source.rankings.alexa.rank.KG
+              - source.rankings.alexa.rank.LA
+              - source.rankings.alexa.rank.LV
+              - source.rankings.alexa.rank.LB
+              - source.rankings.alexa.rank.LS
+              - source.rankings.alexa.rank.LR
+              - source.rankings.alexa.rank.LY
+              - source.rankings.alexa.rank.LI
+              - source.rankings.alexa.rank.LT
+              - source.rankings.alexa.rank.LU
+              - source.rankings.alexa.rank.MO
+              - source.rankings.alexa.rank.MK
+              - source.rankings.alexa.rank.MG
+              - source.rankings.alexa.rank.MW
+              - source.rankings.alexa.rank.MY
+              - source.rankings.alexa.rank.MV
+              - source.rankings.alexa.rank.ML
+              - source.rankings.alexa.rank.MT
+              - source.rankings.alexa.rank.MH
+              - source.rankings.alexa.rank.MQ
+              - source.rankings.alexa.rank.MR
+              - source.rankings.alexa.rank.MU
+              - source.rankings.alexa.rank.YT
+              - source.rankings.alexa.rank.MX
+              - source.rankings.alexa.rank.FM
+              - source.rankings.alexa.rank.MD
+              - source.rankings.alexa.rank.MC
+              - source.rankings.alexa.rank.MN
+              - source.rankings.alexa.rank.ME
+              - source.rankings.alexa.rank.MS
+              - source.rankings.alexa.rank.MA
+              - source.rankings.alexa.rank.MZ
+              - source.rankings.alexa.rank.MM
+              - source.rankings.alexa.rank.NA
+              - source.rankings.alexa.rank.NR
+              - source.rankings.alexa.rank.NP
+              - source.rankings.alexa.rank.NL
+              - source.rankings.alexa.rank.NC
+              - source.rankings.alexa.rank.NZ
+              - source.rankings.alexa.rank.NI
+              - source.rankings.alexa.rank.NE
+              - source.rankings.alexa.rank.NG
+              - source.rankings.alexa.rank.NU
+              - source.rankings.alexa.rank.NF
+              - source.rankings.alexa.rank.MP
+              - source.rankings.alexa.rank.NO
+              - source.rankings.alexa.rank.OM
+              - source.rankings.alexa.rank.PK
+              - source.rankings.alexa.rank.PW
+              - source.rankings.alexa.rank.PS
+              - source.rankings.alexa.rank.PA
+              - source.rankings.alexa.rank.PG
+              - source.rankings.alexa.rank.PY
+              - source.rankings.alexa.rank.PE
+              - source.rankings.alexa.rank.PH
+              - source.rankings.alexa.rank.PN
+              - source.rankings.alexa.rank.PL
+              - source.rankings.alexa.rank.PT
+              - source.rankings.alexa.rank.PR
+              - source.rankings.alexa.rank.QA
+              - source.rankings.alexa.rank.RE
+              - source.rankings.alexa.rank.RO
+              - source.rankings.alexa.rank.RU
+              - source.rankings.alexa.rank.RW
+              - source.rankings.alexa.rank.BL
+              - source.rankings.alexa.rank.SH
+              - source.rankings.alexa.rank.KN
+              - source.rankings.alexa.rank.LC
+              - source.rankings.alexa.rank.MF
+              - source.rankings.alexa.rank.PM
+              - source.rankings.alexa.rank.VC
+              - source.rankings.alexa.rank.WS
+              - source.rankings.alexa.rank.SM
+              - source.rankings.alexa.rank.ST
+              - source.rankings.alexa.rank.SA
+              - source.rankings.alexa.rank.SN
+              - source.rankings.alexa.rank.RS
+              - source.rankings.alexa.rank.SC
+              - source.rankings.alexa.rank.SL
+              - source.rankings.alexa.rank.SG
+              - source.rankings.alexa.rank.SX
+              - source.rankings.alexa.rank.SK
+              - source.rankings.alexa.rank.SI
+              - source.rankings.alexa.rank.SB
+              - source.rankings.alexa.rank.SO
+              - source.rankings.alexa.rank.ZA
+              - source.rankings.alexa.rank.GS
+              - source.rankings.alexa.rank.SS
+              - source.rankings.alexa.rank.ES
+              - source.rankings.alexa.rank.LK
+              - source.rankings.alexa.rank.SD
+              - source.rankings.alexa.rank.SR
+              - source.rankings.alexa.rank.SJ
+              - source.rankings.alexa.rank.SZ
+              - source.rankings.alexa.rank.SE
+              - source.rankings.alexa.rank.CH
+              - source.rankings.alexa.rank.SY
+              - source.rankings.alexa.rank.TW
+              - source.rankings.alexa.rank.TJ
+              - source.rankings.alexa.rank.TZ
+              - source.rankings.alexa.rank.TH
+              - source.rankings.alexa.rank.TL
+              - source.rankings.alexa.rank.TG
+              - source.rankings.alexa.rank.TK
+              - source.rankings.alexa.rank.TO
+              - source.rankings.alexa.rank.TT
+              - source.rankings.alexa.rank.TN
+              - source.rankings.alexa.rank.TR
+              - source.rankings.alexa.rank.TM
+              - source.rankings.alexa.rank.TC
+              - source.rankings.alexa.rank.TV
+              - source.rankings.alexa.rank.UG
+              - source.rankings.alexa.rank.UA
+              - source.rankings.alexa.rank.AE
+              - source.rankings.alexa.rank.GB
+              - source.rankings.alexa.rank.US
+              - source.rankings.alexa.rank.UM
+              - source.rankings.alexa.rank.UY
+              - source.rankings.alexa.rank.UZ
+              - source.rankings.alexa.rank.VU
+              - source.rankings.alexa.rank.VE
+              - source.rankings.alexa.rank.VN
+              - source.rankings.alexa.rank.VG
+              - source.rankings.alexa.rank.VI
+              - source.rankings.alexa.rank.WF
+              - source.rankings.alexa.rank.EH
+              - source.rankings.alexa.rank.YE
+              - source.rankings.alexa.rank.ZM
+              - source.rankings.alexa.rank.ZW
+            nullable: true
+            type: string
+        - description: >
+            This parameter is used for changing the order direction of the
+            result. You can read about sorting results
+            [here](https://newsapi.aylien.com/docs/sorting-results).
+          in: query
+          name: sort_direction
+          schema:
+            default: desc
+            enum:
+              - asc
+              - desc
+            nullable: true
+            type: string
+        - description: >
+            This parameter is used for finding a specific page. You can read
+            more about pagination of results
+            [here](https://newsapi.aylien.com/docs/pagination-of-results).
+          in: query
+          name: cursor
+          schema:
+            default: "*"
+            nullable: true
+            type: string
+        - description: >
+            This parameter is used for specifying number of items in each page
+            You can read more about pagination of results
+            [here](https://newsapi.aylien.com/docs/pagination-of-results)
+          in: query
+          name: per_page
+          schema:
+            default: 10
+            format: int32
+            maximum: 100
+            minimum: 1
+            nullable: true
+            type: integer
+      requestBody:
+        $ref: '#/requestBodies/endpoints/stories'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Stories"
+            text/xml:
+              schema:
+                $ref: "#/components/schemas/Stories"
+          description: An object including an array of stories
+          headers:
+            X-RateLimit-Limit:
+              description: The number of allowed requests in the current period.
+              schema:
+                format: int32
+                type: integer
+            X-RateLimit-Remaining:
+              description: The number of remaining requests in the current period.
+              schema:
+                format: int32
+                type: integer
+            X-RateLimit-Reset:
+              description: >
+                The remaining window before the rate limit resets in UTC [epoch
+                seconds](https://en.wikipedia.org/wiki/Unix_time).
+              schema:
+                format: int64
+                type: integer
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Errors"
+            text/xml:
+              schema:
+                $ref: "#/components/schemas/Errors"
+          description: Unauthorized
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Errors"
+            text/xml:
+              schema:
+                $ref: "#/components/schemas/Errors"
+          description: Not Found
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Errors"
+            text/xml:
+              schema:
+                $ref: "#/components/schemas/Errors"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Errors"
+            text/xml:
+              schema:
+                $ref: "#/components/schemas/Errors"
+          description: Too Many Requests
+          headers:
+            X-RateLimit-Limit:
+              description: The number of allowed requests in the current period.
+              schema:
+                format: int32
+                type: integer
+            X-RateLimit-Remaining:
+              description: The number of remaining requests in the current period.
+              schema:
+                format: int32
+                type: integer
+            X-RateLimit-Reset:
+              description: >
+                The remaining window before the rate limit resets in UTC [epoch
+                seconds](https://en.wikipedia.org/wiki/Unix_time).
+              schema:
+                format: int64
+                type: integer
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Errors"
+            text/xml:
+              schema:
+                $ref: "#/components/schemas/Errors"
+          description: Internal Server Error
+      security:
+        - app_id: []
+        - app_key: []
+      summary: List Stories
   /time_series:
     get:
       tags:
@@ -3555,6 +4061,16 @@ components:
       schema:
         nullable: true
         type: string
+    query:
+      description: >
+        This parameter is used to make an advanced query using $and, $or, $not logical operators
+        and $eq for exact match, $text for a text search and $lt, $gt, $lte, $gte for range queries.
+        value must be a json string.
+      in: query
+      name: query
+      schema:
+        nullable: true
+        type: string
   responses:
     autocompletes:
       content:
@@ -4557,3 +5073,213 @@ components:
       in: header
       name: X-AYLIEN-NewsAPI-Application-Key
       type: apiKey
+requestBodies:
+  endpoints:
+    stories:
+      required: true
+      description: >
+        /stories body schema to perform an advanced search with logical operators
+        and nested objects.
+      content:
+        application/json:
+          schema:
+            $ref: '#/requesteBodies/schemas/LogicalOperator'
+  schemas:
+    LogicalOperator:
+      required: true
+      description: >
+        First level of the /stories json body should be either
+        a logical operator or a Parameter/NestedParemter.
+      content:
+        application/json: 
+          schema:
+            oneOf:
+              - $ref: '#/requesteBodies/schemas/Logicals'
+              - $ref: '#/requesteBodies/schemas/Params'
+    Logicals: 
+      title: One of the logical operators such as $and, $or, $not
+      type: object
+      properties: 
+        $and: 
+          $ref: '#/requesteBodies/schemas/Logical'
+        $or: 
+          $ref: '#/requesteBodies/schemas/Logical'
+        $not: 
+          $ref: '#/requesteBodies/schemas/Logical'
+    Logical:
+      title: Logical operators
+      type: array
+      items:
+        anyOf: 
+          - $ref: '#/requesteBodies/schemas/Logicals'
+          - $ref: '#/requesteBodies/schemas/Params'
+    Params:
+      title: Parameter defines the search query on a field
+      type: object
+      properties:
+        author.id:
+          $ref: '#/requestBodies/schemas/Parameter'
+        author.name:
+          $ref: '#/requestBodies/schemas/Parameter'
+        body:
+          $ref: '#/requestBodies/schemas/Parameter'
+        categories.confident:
+          $ref: '#/requestBodies/schemas/Parameter'
+        categories.id:
+          $ref: '#/requestBodies/schemas/Parameter'
+        categories.level:
+          $ref: '#/requestBodies/schemas/Parameter'
+        categories.taxonomy:
+          $ref: '#/requestBodies/schemas/Parameter'
+        clusters:
+          $ref: '#/requestBodies/schemas/Parameter'
+        links.permalink:
+          $ref: '#/requestBodies/schemas/Parameter'
+        entities.body.links.dbpedia:
+          $ref: '#/requestBodies/schemas/Parameter'
+        entities.body.text:
+          $ref: '#/requestBodies/schemas/Parameter'
+        entities.body.type:
+          $ref: '#/requestBodies/schemas/Parameter'
+        entities.title.links.dbpedia:
+          $ref: '#/requestBodies/schemas/Parameter'
+        entities.title.text:
+          $ref: '#/requestBodies/schemas/Parameter'
+        entities.title.type:
+          $ref: '#/requestBodies/schemas/Parameter'
+        id:
+          $ref: '#/requestBodies/schemas/Parameter'
+        language:
+          $ref: '#/requestBodies/schemas/Parameter'
+        media.images.content.length.max:
+          $ref: '#/requestBodies/schemas/Parameter'
+        media.images.content.length.min:
+          $ref: '#/requestBodies/schemas/Parameter'
+        media.images.count.max:
+          $ref: '#/requestBodies/schemas/Parameter'
+        media.images.count.min:
+          $ref: '#/requestBodies/schemas/Parameter'
+        media.images.format:
+          $ref: '#/requestBodies/schemas/Parameter'
+        media.images.height.max:
+          $ref: '#/requestBodies/schemas/Parameter'
+        media.images.height.min:
+          $ref: '#/requestBodies/schemas/Parameter'
+        media.images.width.max:
+          $ref: '#/requestBodies/schemas/Parameter'
+        media.images.width.min:
+          $ref: '#/requestBodies/schemas/Parameter'
+        media.videos.count.max:
+          $ref: '#/requestBodies/schemas/Parameter'
+        media.videos.count.min:
+          $ref: '#/requestBodies/schemas/Parameter'
+        sentiment.body.polarity:
+          $ref: '#/requestBodies/schemas/Parameter'
+        sentiment.title.polarity:
+          $ref: '#/requestBodies/schemas/Parameter'
+        social.shares.count.facebook.max:
+          $ref: '#/requestBodies/schemas/Parameter'
+        social.shares.count.facebook.min:
+          $ref: '#/requestBodies/schemas/Parameter'
+        social.shares.count.reddit.max:
+          $ref: '#/requestBodies/schemas/Parameter'
+        social.shares.count.reddit.min:
+          $ref: '#/requestBodies/schemas/Parameter'
+        source.domain:
+          $ref: '#/requestBodies/schemas/Parameter'
+        source.id:
+          $ref: '#/requestBodies/schemas/Parameter'
+        source.links.in.count.max:
+          $ref: '#/requestBodies/schemas/Parameter'
+        source.links.in.count.min:
+          $ref: '#/requestBodies/schemas/Parameter'
+        source.locations.city:
+          $ref: '#/requestBodies/schemas/Parameter'
+        source.locations.country:
+          $ref: '#/requestBodies/schemas/Parameter'
+        source.locations.state:
+          $ref: '#/requestBodies/schemas/Parameter'
+        source.rankings.alexa.country:
+          $ref: '#/requestBodies/schemas/Parameter'
+        source.rankings.alexa.rank.max:
+          $ref: '#/requestBodies/schemas/Parameter'
+        source.rankings.alexa.rank.min:
+          $ref: '#/requestBodies/schemas/Parameter'
+        source.scopes.city:
+          $ref: '#/requestBodies/schemas/Parameter'
+        source.scopes.country:
+          $ref: '#/requestBodies/schemas/Parameter'
+        source.scopes.level:
+          $ref: '#/requestBodies/schemas/Parameter'
+        source.scopes.state:
+          $ref: '#/requestBodies/schemas/Parameter'
+        story_url:
+          $ref: '#/requestBodies/schemas/Parameter'
+        story_language:
+          $ref: '#/requestBodies/schemas/Parameter'
+        text:
+          $ref: '#/requestBodies/schemas/Parameter'
+        title:
+          $ref: '#/requestBodies/schemas/Parameter'
+        translations.en.body:
+          $ref: '#/requestBodies/schemas/Parameter'
+        translations.en.text:
+          $ref: '#/requestBodies/schemas/Parameter'
+        translations.en.title:
+          $ref: '#/requestBodies/schemas/Parameter'
+        entity:
+          oneOf:
+            - $ref: '#/requestBodies/schemas/Entity'
+            - $ref: '#/requestBodies/schemas/Logicals'
+    Parameter:
+      title: Parameter defines the search query on a field
+      type: object
+      properties:
+        $eq:
+          description: Perform an exact match search on the given value
+          anyOf: 
+            - type: string
+            - type: number
+        $text:
+          description: Perform a text search on the given value
+          anyOf: 
+            - type: string
+            - type: number
+        $in:
+          description: Perform a search on an array of values
+          type: array
+          items: 
+            anyOf:
+              - type: string
+              - type: number
+        $gt:
+          description: Perform a greater than search on the given value
+          type: number
+        $gte:
+          description: Perform a greater than equal search on the given value
+          type: number
+        $lt:
+          description: Perform a less than search on the given value
+          type: number
+        $lte:
+          description: Perform a less than equal search on the given value
+          type: number
+        $boost:
+          description: Gives a weight to the field on performing the query
+          type: number        
+    Entity:
+      type: object
+      title: To perform a nested search on entities use this.
+      properties:
+        name:
+          $ref: '#/requestBodies/schemas/Parameter'
+        sentiment:
+          $ref: '#/requestBodies/schemas/Parameter'
+        element:
+          $ref: '#/requestBodies/schemas/Parameter'
+        link.wikipedia:
+          $ref: '#/requestBodies/schemas/Parameter'
+        stock_ticker:
+          $ref: '#/requestBodies/schemas/Parameter'
+        type:
+          $ref: '#/requestBodies/schemas/Parameter'

--- a/aylien/v1/news/api.yaml
+++ b/aylien/v1/news/api.yaml
@@ -4973,22 +4973,16 @@ components:
       type: object
       properties:
         $and:
-          allOf:
-            - title: Logical operator And
-            - $ref: '#/components/schemas/Logical'
+          $ref: '#/components/schemas/Logical'
         $or:
-          allOf:
-            - title: Logical operator Or
-            - $ref: '#/components/schemas/Logical'
+          $ref: '#/components/schemas/Logical'
         $not:
-          allOf:
-            - title: Logical operator Not
-            - $ref: '#/components/schemas/Logical'
+          $ref: '#/components/schemas/Logical'
     Logical:
       title: Logical operators
       type: array
       items:
-        anyOf: 
+        anyOf:
           - $ref: '#/components/schemas/Logicals'
           - $ref: '#/components/schemas/Params'
     Params:
@@ -5115,19 +5109,19 @@ components:
       properties:
         $eq:
           title: Perform an exact match search on the given value
-          anyOf: 
+          oneOf: 
             - type: string
             - type: number
         $text:
           title: Perform a text search on the given value
-          anyOf: 
+          oneOf: 
             - type: string
             - type: number
         $in:
           title: Perform a search on an array of values
           type: array
           items: 
-            anyOf:
+            oneOf:
               - type: string
               - type: number
         $gt:

--- a/aylien/v1/news/api.yaml
+++ b/aylien/v1/news/api.yaml
@@ -1792,96 +1792,10 @@ paths:
         real-time and stores information about them, or metadata. Below you can
         see all of the query parameters, and JSON schema for the body, which you
         can use to narrow down your query.
-      operationId: listStories
+      operationId: advancedListStories
       parameters:
-        - $ref: "#/components/parameters/id"
-        - $ref: "#/components/parameters/notid"
-        - $ref: "#/components/parameters/title"
-        - $ref: "#/components/parameters/body"
-        - $ref: "#/components/parameters/text"
-        - $ref: "#/components/parameters/translations_en_title"
-        - $ref: "#/components/parameters/translations_en_body"
-        - $ref: "#/components/parameters/translations_en_text"
-        - $ref: "#/components/parameters/language"
-        - $ref: "#/components/parameters/notlanguage"
-        - $ref: "#/components/parameters/links_permalink"
-        - $ref: "#/components/parameters/notlinks_permalink"
         - $ref: "#/components/parameters/published_at_start"
         - $ref: "#/components/parameters/published_at_end"
-        - $ref: "#/components/parameters/categories_taxonomy"
-        - $ref: "#/components/parameters/categories_confident"
-        - $ref: "#/components/parameters/categories_id"
-        - $ref: "#/components/parameters/notcategories_id"
-        - $ref: "#/components/parameters/categories_label"
-        - $ref: "#/components/parameters/notcategories_label"
-        - $ref: "#/components/parameters/categories_level"
-        - $ref: "#/components/parameters/notcategories_level"
-        - $ref: "#/components/parameters/entities_title_text"
-        - $ref: "#/components/parameters/notentities_title_text"
-        - $ref: "#/components/parameters/entities_title_type"
-        - $ref: "#/components/parameters/notentities_title_type"
-        - $ref: "#/components/parameters/entities_title_links_dbpedia"
-        - $ref: "#/components/parameters/notentities_title_links_dbpedia"
-        - $ref: "#/components/parameters/entities_body_text"
-        - $ref: "#/components/parameters/notentities_body_text"
-        - $ref: "#/components/parameters/entities_body_type"
-        - $ref: "#/components/parameters/notentities_body_type"
-        - $ref: "#/components/parameters/entities_body_links_dbpedia"
-        - $ref: "#/components/parameters/notentities_body_links_dbpedia"
-        - $ref: "#/components/parameters/sentiment_title_polarity"
-        - $ref: "#/components/parameters/notsentiment_title_polarity"
-        - $ref: "#/components/parameters/sentiment_body_polarity"
-        - $ref: "#/components/parameters/notsentiment_body_polarity"
-        - $ref: "#/components/parameters/media_images_count_min"
-        - $ref: "#/components/parameters/media_images_count_max"
-        - $ref: "#/components/parameters/media_images_width_min"
-        - $ref: "#/components/parameters/media_images_width_max"
-        - $ref: "#/components/parameters/media_images_height_min"
-        - $ref: "#/components/parameters/media_images_height_max"
-        - $ref: "#/components/parameters/media_images_content_length_min"
-        - $ref: "#/components/parameters/media_images_content_length_max"
-        - $ref: "#/components/parameters/media_images_format"
-        - $ref: "#/components/parameters/notmedia_images_format"
-        - $ref: "#/components/parameters/media_videos_count_min"
-        - $ref: "#/components/parameters/media_videos_count_max"
-        - $ref: "#/components/parameters/author_id"
-        - $ref: "#/components/parameters/notauthor_id"
-        - $ref: "#/components/parameters/author_name"
-        - $ref: "#/components/parameters/notauthor_name"
-        - $ref: "#/components/parameters/source_id"
-        - $ref: "#/components/parameters/notsource_id"
-        - $ref: "#/components/parameters/source_name"
-        - $ref: "#/components/parameters/notsource_name"
-        - $ref: "#/components/parameters/source_domain"
-        - $ref: "#/components/parameters/notsource_domain"
-        - $ref: "#/components/parameters/source_locations_country"
-        - $ref: "#/components/parameters/notsource_locations_country"
-        - $ref: "#/components/parameters/source_locations_state"
-        - $ref: "#/components/parameters/notsource_locations_state"
-        - $ref: "#/components/parameters/source_locations_city"
-        - $ref: "#/components/parameters/notsource_locations_city"
-        - $ref: "#/components/parameters/source_scopes_country"
-        - $ref: "#/components/parameters/notsource_scopes_country"
-        - $ref: "#/components/parameters/source_scopes_state"
-        - $ref: "#/components/parameters/notsource_scopes_state"
-        - $ref: "#/components/parameters/source_scopes_city"
-        - $ref: "#/components/parameters/notsource_scopes_city"
-        - $ref: "#/components/parameters/source_scopes_level"
-        - $ref: "#/components/parameters/notsource_scopes_level"
-        - $ref: "#/components/parameters/source_links_in_count_min"
-        - $ref: "#/components/parameters/source_links_in_count_max"
-        - $ref: "#/components/parameters/source_rankings_alexa_rank_min"
-        - $ref: "#/components/parameters/source_rankings_alexa_rank_max"
-        - $ref: "#/components/parameters/source_rankings_alexa_country"
-        - $ref: "#/components/parameters/social_shares_count_facebook_min"
-        - $ref: "#/components/parameters/social_shares_count_facebook_max"
-        - $ref: "#/components/parameters/social_shares_count_google_plus_min"
-        - $ref: "#/components/parameters/social_shares_count_google_plus_max"
-        - $ref: "#/components/parameters/social_shares_count_linkedin_min"
-        - $ref: "#/components/parameters/social_shares_count_linkedin_max"
-        - $ref: "#/components/parameters/social_shares_count_reddit_min"
-        - $ref: "#/components/parameters/social_shares_count_reddit_max"
-        - $ref: "#/components/parameters/clusters"
         - $ref: "#/components/parameters/return"
         - description: >
             This parameter is used for changing the order column of the results.
@@ -2193,7 +2107,7 @@ paths:
             nullable: true
             type: integer
       requestBody:
-        $ref: '#/requestBodies/endpoints/stories'
+        $ref: '#/components/requestBodies/StoriesBody'
       responses:
         "200":
           content:
@@ -5054,6 +4968,200 @@ components:
           description: The detailed description of the warning.
           type: string
       type: object
+    Logicals: 
+      title: One of the logical operators such as $and, $or, $not
+      type: object
+      properties:
+        '$and':
+          allOf:
+            - title: Logical operator And
+            - $ref: '#/components/schemas/Logical'
+        '$or':
+          allOf:
+            - title: Logical operator Or
+            - $ref: '#/components/schemas/Logical'
+        '$not':
+          allOf:
+            - title: Logical operator Not
+            - $ref: '#/components/schemas/Logical'
+    Logical:
+      title: Logical operators
+      type: array
+      items:
+        anyOf: 
+          - $ref: '#/components/schemas/Logicals'
+          - $ref: '#/components/schemas/Params'
+    Params:
+      title: Parameter defines the search query on a field
+      type: object
+      properties:
+        author.id:
+          $ref: '#/components/schemas/Parameter'
+        author.name:
+          $ref: '#/components/schemas/Parameter'
+        body:
+          $ref: '#/components/schemas/Parameter'
+        categories.confident:
+          $ref: '#/components/schemas/Parameter'
+        categories.id:
+          $ref: '#/components/schemas/Parameter'
+        categories.level:
+          $ref: '#/components/schemas/Parameter'
+        categories.taxonomy:
+          $ref: '#/components/schemas/Parameter'
+        clusters:
+          $ref: '#/components/schemas/Parameter'
+        links.permalink:
+          $ref: '#/components/schemas/Parameter'
+        entities.body.links.dbpedia:
+          $ref: '#/components/schemas/Parameter'
+        entities.body.text:
+          $ref: '#/components/schemas/Parameter'
+        entities.body.type:
+          $ref: '#/components/schemas/Parameter'
+        entities.title.links.dbpedia:
+          $ref: '#/components/schemas/Parameter'
+        entities.title.text:
+          $ref: '#/components/schemas/Parameter'
+        entities.title.type:
+          $ref: '#/components/schemas/Parameter'
+        id:
+          $ref: '#/components/schemas/Parameter'
+        language:
+          $ref: '#/components/schemas/Parameter'
+        media.images.content.length.max:
+          $ref: '#/components/schemas/Parameter'
+        media.images.content.length.min:
+          $ref: '#/components/schemas/Parameter'
+        media.images.count.max:
+          $ref: '#/components/schemas/Parameter'
+        media.images.count.min:
+          $ref: '#/components/schemas/Parameter'
+        media.images.format:
+          $ref: '#/components/schemas/Parameter'
+        media.images.height.max:
+          $ref: '#/components/schemas/Parameter'
+        media.images.height.min:
+          $ref: '#/components/schemas/Parameter'
+        media.images.width.max:
+          $ref: '#/components/schemas/Parameter'
+        media.images.width.min:
+          $ref: '#/components/schemas/Parameter'
+        media.videos.count.max:
+          $ref: '#/components/schemas/Parameter'
+        media.videos.count.min:
+          $ref: '#/components/schemas/Parameter'
+        sentiment.body.polarity:
+          $ref: '#/components/schemas/Parameter'
+        sentiment.title.polarity:
+          $ref: '#/components/schemas/Parameter'
+        social.shares.count.facebook.max:
+          $ref: '#/components/schemas/Parameter'
+        social.shares.count.facebook.min:
+          $ref: '#/components/schemas/Parameter'
+        social.shares.count.reddit.max:
+          $ref: '#/components/schemas/Parameter'
+        social.shares.count.reddit.min:
+          $ref: '#/components/schemas/Parameter'
+        source.domain:
+          $ref: '#/components/schemas/Parameter'
+        source.id:
+          $ref: '#/components/schemas/Parameter'
+        source.links.in.count.max:
+          $ref: '#/components/schemas/Parameter'
+        source.links.in.count.min:
+          $ref: '#/components/schemas/Parameter'
+        source.locations.city:
+          $ref: '#/components/schemas/Parameter'
+        source.locations.country:
+          $ref: '#/components/schemas/Parameter'
+        source.locations.state:
+          $ref: '#/components/schemas/Parameter'
+        source.rankings.alexa.country:
+          $ref: '#/components/schemas/Parameter'
+        source.rankings.alexa.rank.max:
+          $ref: '#/components/schemas/Parameter'
+        source.rankings.alexa.rank.min:
+          $ref: '#/components/schemas/Parameter'
+        source.scopes.city:
+          $ref: '#/components/schemas/Parameter'
+        source.scopes.country:
+          $ref: '#/components/schemas/Parameter'
+        source.scopes.level:
+          $ref: '#/components/schemas/Parameter'
+        source.scopes.state:
+          $ref: '#/components/schemas/Parameter'
+        story_url:
+          $ref: '#/components/schemas/Parameter'
+        story_language:
+          $ref: '#/components/schemas/Parameter'
+        text:
+          $ref: '#/components/schemas/Parameter'
+        title:
+          $ref: '#/components/schemas/Parameter'
+        translations.en.body:
+          $ref: '#/components/schemas/Parameter'
+        translations.en.text:
+          $ref: '#/components/schemas/Parameter'
+        translations.en.title:
+          $ref: '#/components/schemas/Parameter'
+        entity:
+          oneOf:
+            - $ref: '#/components/schemas/NestedEntity'
+            - $ref: '#/components/schemas/Logicals'
+    Parameter:
+      title: Parameter defines the search query on a field
+      type: object
+      properties:
+        '$eq':
+          title: Perform an exact match search on the given value
+          anyOf: 
+            - type: string
+            - type: number
+        '$text':
+          title: Perform a text search on the given value
+          anyOf: 
+            - type: string
+            - type: number
+        '$in':
+          title: Perform a search on an array of values
+          type: array
+          items: 
+            anyOf:
+              - type: string
+              - type: number
+        '$gt':
+          title: Perform a greater than search on the given value
+          type: number
+        '$gte':
+          title: Perform a greater than equal search on the given value
+          type: number
+        '$lt':
+          title: Perform a less than search on the given value
+          type: number
+        '$lte':
+          title: Perform a less than equal search on the given value
+          type: number
+        '$boost':
+          title: Gives a weight to the field on performing the query
+          type: number        
+    NestedEntity:
+      type: object
+      title: To perform a nested search on entities use this.
+      properties:
+        name:
+          $ref: '#/components/schemas/Parameter'
+        sentiment:
+          $ref: '#/components/schemas/Parameter'
+        element:
+          $ref: '#/components/schemas/Parameter'
+        link.wikipedia:
+          $ref: '#/components/schemas/Parameter'
+        stock_ticker:
+          $ref: '#/components/schemas/Parameter'
+        type:
+          $ref: '#/components/schemas/Parameter'
+
   securitySchemes:
     app_id:
       x-auth-id-alias: true
@@ -5073,9 +5181,8 @@ components:
       in: header
       name: X-AYLIEN-NewsAPI-Application-Key
       type: apiKey
-requestBodies:
-  endpoints:
-    stories:
+  requestBodies:
+    StoriesBody:
       required: true
       description: >
         /stories body schema to perform an advanced search with logical operators
@@ -5083,203 +5190,6 @@ requestBodies:
       content:
         application/json:
           schema:
-            $ref: '#/requesteBodies/schemas/LogicalOperator'
-  schemas:
-    LogicalOperator:
-      required: true
-      description: >
-        First level of the /stories json body should be either
-        a logical operator or a Parameter/NestedParemter.
-      content:
-        application/json: 
-          schema:
             oneOf:
-              - $ref: '#/requesteBodies/schemas/Logicals'
-              - $ref: '#/requesteBodies/schemas/Params'
-    Logicals: 
-      title: One of the logical operators such as $and, $or, $not
-      type: object
-      properties: 
-        $and: 
-          $ref: '#/requesteBodies/schemas/Logical'
-        $or: 
-          $ref: '#/requesteBodies/schemas/Logical'
-        $not: 
-          $ref: '#/requesteBodies/schemas/Logical'
-    Logical:
-      title: Logical operators
-      type: array
-      items:
-        anyOf: 
-          - $ref: '#/requesteBodies/schemas/Logicals'
-          - $ref: '#/requesteBodies/schemas/Params'
-    Params:
-      title: Parameter defines the search query on a field
-      type: object
-      properties:
-        author.id:
-          $ref: '#/requestBodies/schemas/Parameter'
-        author.name:
-          $ref: '#/requestBodies/schemas/Parameter'
-        body:
-          $ref: '#/requestBodies/schemas/Parameter'
-        categories.confident:
-          $ref: '#/requestBodies/schemas/Parameter'
-        categories.id:
-          $ref: '#/requestBodies/schemas/Parameter'
-        categories.level:
-          $ref: '#/requestBodies/schemas/Parameter'
-        categories.taxonomy:
-          $ref: '#/requestBodies/schemas/Parameter'
-        clusters:
-          $ref: '#/requestBodies/schemas/Parameter'
-        links.permalink:
-          $ref: '#/requestBodies/schemas/Parameter'
-        entities.body.links.dbpedia:
-          $ref: '#/requestBodies/schemas/Parameter'
-        entities.body.text:
-          $ref: '#/requestBodies/schemas/Parameter'
-        entities.body.type:
-          $ref: '#/requestBodies/schemas/Parameter'
-        entities.title.links.dbpedia:
-          $ref: '#/requestBodies/schemas/Parameter'
-        entities.title.text:
-          $ref: '#/requestBodies/schemas/Parameter'
-        entities.title.type:
-          $ref: '#/requestBodies/schemas/Parameter'
-        id:
-          $ref: '#/requestBodies/schemas/Parameter'
-        language:
-          $ref: '#/requestBodies/schemas/Parameter'
-        media.images.content.length.max:
-          $ref: '#/requestBodies/schemas/Parameter'
-        media.images.content.length.min:
-          $ref: '#/requestBodies/schemas/Parameter'
-        media.images.count.max:
-          $ref: '#/requestBodies/schemas/Parameter'
-        media.images.count.min:
-          $ref: '#/requestBodies/schemas/Parameter'
-        media.images.format:
-          $ref: '#/requestBodies/schemas/Parameter'
-        media.images.height.max:
-          $ref: '#/requestBodies/schemas/Parameter'
-        media.images.height.min:
-          $ref: '#/requestBodies/schemas/Parameter'
-        media.images.width.max:
-          $ref: '#/requestBodies/schemas/Parameter'
-        media.images.width.min:
-          $ref: '#/requestBodies/schemas/Parameter'
-        media.videos.count.max:
-          $ref: '#/requestBodies/schemas/Parameter'
-        media.videos.count.min:
-          $ref: '#/requestBodies/schemas/Parameter'
-        sentiment.body.polarity:
-          $ref: '#/requestBodies/schemas/Parameter'
-        sentiment.title.polarity:
-          $ref: '#/requestBodies/schemas/Parameter'
-        social.shares.count.facebook.max:
-          $ref: '#/requestBodies/schemas/Parameter'
-        social.shares.count.facebook.min:
-          $ref: '#/requestBodies/schemas/Parameter'
-        social.shares.count.reddit.max:
-          $ref: '#/requestBodies/schemas/Parameter'
-        social.shares.count.reddit.min:
-          $ref: '#/requestBodies/schemas/Parameter'
-        source.domain:
-          $ref: '#/requestBodies/schemas/Parameter'
-        source.id:
-          $ref: '#/requestBodies/schemas/Parameter'
-        source.links.in.count.max:
-          $ref: '#/requestBodies/schemas/Parameter'
-        source.links.in.count.min:
-          $ref: '#/requestBodies/schemas/Parameter'
-        source.locations.city:
-          $ref: '#/requestBodies/schemas/Parameter'
-        source.locations.country:
-          $ref: '#/requestBodies/schemas/Parameter'
-        source.locations.state:
-          $ref: '#/requestBodies/schemas/Parameter'
-        source.rankings.alexa.country:
-          $ref: '#/requestBodies/schemas/Parameter'
-        source.rankings.alexa.rank.max:
-          $ref: '#/requestBodies/schemas/Parameter'
-        source.rankings.alexa.rank.min:
-          $ref: '#/requestBodies/schemas/Parameter'
-        source.scopes.city:
-          $ref: '#/requestBodies/schemas/Parameter'
-        source.scopes.country:
-          $ref: '#/requestBodies/schemas/Parameter'
-        source.scopes.level:
-          $ref: '#/requestBodies/schemas/Parameter'
-        source.scopes.state:
-          $ref: '#/requestBodies/schemas/Parameter'
-        story_url:
-          $ref: '#/requestBodies/schemas/Parameter'
-        story_language:
-          $ref: '#/requestBodies/schemas/Parameter'
-        text:
-          $ref: '#/requestBodies/schemas/Parameter'
-        title:
-          $ref: '#/requestBodies/schemas/Parameter'
-        translations.en.body:
-          $ref: '#/requestBodies/schemas/Parameter'
-        translations.en.text:
-          $ref: '#/requestBodies/schemas/Parameter'
-        translations.en.title:
-          $ref: '#/requestBodies/schemas/Parameter'
-        entity:
-          oneOf:
-            - $ref: '#/requestBodies/schemas/Entity'
-            - $ref: '#/requestBodies/schemas/Logicals'
-    Parameter:
-      title: Parameter defines the search query on a field
-      type: object
-      properties:
-        $eq:
-          description: Perform an exact match search on the given value
-          anyOf: 
-            - type: string
-            - type: number
-        $text:
-          description: Perform a text search on the given value
-          anyOf: 
-            - type: string
-            - type: number
-        $in:
-          description: Perform a search on an array of values
-          type: array
-          items: 
-            anyOf:
-              - type: string
-              - type: number
-        $gt:
-          description: Perform a greater than search on the given value
-          type: number
-        $gte:
-          description: Perform a greater than equal search on the given value
-          type: number
-        $lt:
-          description: Perform a less than search on the given value
-          type: number
-        $lte:
-          description: Perform a less than equal search on the given value
-          type: number
-        $boost:
-          description: Gives a weight to the field on performing the query
-          type: number        
-    Entity:
-      type: object
-      title: To perform a nested search on entities use this.
-      properties:
-        name:
-          $ref: '#/requestBodies/schemas/Parameter'
-        sentiment:
-          $ref: '#/requestBodies/schemas/Parameter'
-        element:
-          $ref: '#/requestBodies/schemas/Parameter'
-        link.wikipedia:
-          $ref: '#/requestBodies/schemas/Parameter'
-        stock_ticker:
-          $ref: '#/requestBodies/schemas/Parameter'
-        type:
-          $ref: '#/requestBodies/schemas/Parameter'
+              - $ref: '#/components/schemas/Logicals'
+              - $ref: '#/components/schemas/Params'

--- a/aylien/v1/news/api.yaml
+++ b/aylien/v1/news/api.yaml
@@ -5304,7 +5304,7 @@ components:
           $ref: '#/components/schemas/Query'
         element:
           $ref: '#/components/schemas/Query'
-        link.wikipedia:
+        links.wikipedia:
           $ref: '#/components/schemas/Query'
         stock_ticker:
           $ref: '#/components/schemas/Query'

--- a/aylien/v1/news/api.yaml
+++ b/aylien/v1/news/api.yaml
@@ -511,14 +511,22 @@ paths:
         - $ref: "#/components/parameters/notentities_title_text"
         - $ref: "#/components/parameters/entities_title_type"
         - $ref: "#/components/parameters/notentities_title_type"
+        - $ref: "#/components/parameters/entities_title_stock_ticker"
+        - $ref: "#/components/parameters/notentities_title_stock_ticker"
         - $ref: "#/components/parameters/entities_title_links_dbpedia"
         - $ref: "#/components/parameters/notentities_title_links_dbpedia"
+        - $ref: "#/components/parameters/entities_title_links_wikipedia"
+        - $ref: "#/components/parameters/notentities_title_links_wikipedia"
         - $ref: "#/components/parameters/entities_body_text"
         - $ref: "#/components/parameters/notentities_body_text"
         - $ref: "#/components/parameters/entities_body_type"
         - $ref: "#/components/parameters/notentities_body_type"
+        - $ref: "#/components/parameters/entities_body_stock_ticker"
+        - $ref: "#/components/parameters/notentities_body_stock_ticker"
         - $ref: "#/components/parameters/entities_body_links_dbpedia"
         - $ref: "#/components/parameters/notentities_body_links_dbpedia"
+        - $ref: "#/components/parameters/entities_body_links_wikipedia"
+        - $ref: "#/components/parameters/notentities_body_links_wikipedia"
         - $ref: "#/components/parameters/sentiment_title_polarity"
         - $ref: "#/components/parameters/notsentiment_title_polarity"
         - $ref: "#/components/parameters/sentiment_body_polarity"
@@ -1002,14 +1010,22 @@ paths:
       - $ref: "#/components/parameters/notentities_title_text"
       - $ref: "#/components/parameters/entities_title_type"
       - $ref: "#/components/parameters/notentities_title_type"
+      - $ref: "#/components/parameters/entities_title_stock_ticker"
+      - $ref: "#/components/parameters/notentities_title_stock_ticker"
       - $ref: "#/components/parameters/entities_title_links_dbpedia"
       - $ref: "#/components/parameters/notentities_title_links_dbpedia"
+      - $ref: "#/components/parameters/entities_title_links_wikipedia"
+      - $ref: "#/components/parameters/notentities_title_links_wikipedia"
       - $ref: "#/components/parameters/entities_body_text"
       - $ref: "#/components/parameters/notentities_body_text"
       - $ref: "#/components/parameters/entities_body_type"
       - $ref: "#/components/parameters/notentities_body_type"
+      - $ref: "#/components/parameters/entities_body_stock_ticker"
+      - $ref: "#/components/parameters/notentities_body_stock_ticker"
       - $ref: "#/components/parameters/entities_body_links_dbpedia"
       - $ref: "#/components/parameters/notentities_body_links_dbpedia"
+      - $ref: "#/components/parameters/entities_body_links_wikipedia"
+      - $ref: "#/components/parameters/notentities_body_links_wikipedia"
       - $ref: "#/components/parameters/sentiment_title_polarity"
       - $ref: "#/components/parameters/notsentiment_title_polarity"
       - $ref: "#/components/parameters/sentiment_body_polarity"
@@ -1316,14 +1332,22 @@ paths:
         - $ref: "#/components/parameters/notentities_title_text"
         - $ref: "#/components/parameters/entities_title_type"
         - $ref: "#/components/parameters/notentities_title_type"
+        - $ref: "#/components/parameters/entities_title_stock_ticker"
+        - $ref: "#/components/parameters/notentities_title_stock_ticker"
         - $ref: "#/components/parameters/entities_title_links_dbpedia"
         - $ref: "#/components/parameters/notentities_title_links_dbpedia"
+        - $ref: "#/components/parameters/entities_title_links_wikipedia"
+        - $ref: "#/components/parameters/notentities_title_links_wikipedia"
         - $ref: "#/components/parameters/entities_body_text"
         - $ref: "#/components/parameters/notentities_body_text"
         - $ref: "#/components/parameters/entities_body_type"
         - $ref: "#/components/parameters/notentities_body_type"
+        - $ref: "#/components/parameters/entities_body_stock_ticker"
+        - $ref: "#/components/parameters/notentities_body_stock_ticker"
         - $ref: "#/components/parameters/entities_body_links_dbpedia"
         - $ref: "#/components/parameters/notentities_body_links_dbpedia"
+        - $ref: "#/components/parameters/entities_body_links_wikipedia"
+        - $ref: "#/components/parameters/notentities_body_links_wikipedia"
         - $ref: "#/components/parameters/sentiment_title_polarity"
         - $ref: "#/components/parameters/notsentiment_title_polarity"
         - $ref: "#/components/parameters/sentiment_body_polarity"
@@ -2243,14 +2267,22 @@ paths:
         - $ref: "#/components/parameters/notentities_title_text"
         - $ref: "#/components/parameters/entities_title_type"
         - $ref: "#/components/parameters/notentities_title_type"
+        - $ref: "#/components/parameters/entities_title_stock_ticker"
+        - $ref: "#/components/parameters/notentities_title_stock_ticker"
         - $ref: "#/components/parameters/entities_title_links_dbpedia"
         - $ref: "#/components/parameters/notentities_title_links_dbpedia"
+        - $ref: "#/components/parameters/entities_title_links_wikipedia"
+        - $ref: "#/components/parameters/notentities_title_links_wikipedia"
         - $ref: "#/components/parameters/entities_body_text"
         - $ref: "#/components/parameters/notentities_body_text"
         - $ref: "#/components/parameters/entities_body_type"
         - $ref: "#/components/parameters/notentities_body_type"
+        - $ref: "#/components/parameters/entities_body_stock_ticker"
+        - $ref: "#/components/parameters/notentities_body_stock_ticker"
         - $ref: "#/components/parameters/entities_body_links_dbpedia"
         - $ref: "#/components/parameters/notentities_body_links_dbpedia"
+        - $ref: "#/components/parameters/entities_body_links_wikipedia"
+        - $ref: "#/components/parameters/notentities_body_links_wikipedia"
         - $ref: "#/components/parameters/sentiment_title_polarity"
         - $ref: "#/components/parameters/notsentiment_title_polarity"
         - $ref: "#/components/parameters/sentiment_body_polarity"
@@ -2475,14 +2507,22 @@ paths:
         - $ref: "#/components/parameters/notentities_title_text"
         - $ref: "#/components/parameters/entities_title_type"
         - $ref: "#/components/parameters/notentities_title_type"
+        - $ref: "#/components/parameters/entities_title_stock_ticker"
+        - $ref: "#/components/parameters/notentities_title_stock_ticker"
         - $ref: "#/components/parameters/entities_title_links_dbpedia"
         - $ref: "#/components/parameters/notentities_title_links_dbpedia"
+        - $ref: "#/components/parameters/entities_title_links_wikipedia"
+        - $ref: "#/components/parameters/notentities_title_links_wikipedia"
         - $ref: "#/components/parameters/entities_body_text"
         - $ref: "#/components/parameters/notentities_body_text"
         - $ref: "#/components/parameters/entities_body_type"
         - $ref: "#/components/parameters/notentities_body_type"
+        - $ref: "#/components/parameters/entities_body_stock_ticker"
+        - $ref: "#/components/parameters/notentities_body_stock_ticker"
         - $ref: "#/components/parameters/entities_body_links_dbpedia"
         - $ref: "#/components/parameters/notentities_body_links_dbpedia"
+        - $ref: "#/components/parameters/entities_body_links_wikipedia"
+        - $ref: "#/components/parameters/notentities_body_links_wikipedia"
         - $ref: "#/components/parameters/sentiment_title_polarity"
         - $ref: "#/components/parameters/notsentiment_title_polarity"
         - $ref: "#/components/parameters/sentiment_body_polarity"
@@ -2811,6 +2851,20 @@ components:
         nullable: true
         type: array
       style: form
+    entities_body_links_wikipedia:
+      description: >
+        This parameter is used to find stories based on the specified entities
+        wickipedia URL in the body of stories. You can read more about working with
+        entities [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: entities.body.links.wikipedia[]
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
     entities_body_text:
       description: >
         This parameter is used to find stories based on the specified entities
@@ -2839,6 +2893,20 @@ components:
         nullable: true
         type: array
       style: form
+    entities_body_stock_ticker:
+      description: >
+        This parameter is used to find stories based on the specified entities
+        `stock_ticker` in the body of stories. You can read more about working with
+        entities [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: entities.body.stock_ticker[]
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
     entities_title_links_dbpedia:
       description: >
         This parameter is used to find stories based on the specified entities
@@ -2847,6 +2915,20 @@ components:
       explode: true
       in: query
       name: entities.title.links.dbpedia[]
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
+    entities_title_links_wikipedia:
+      description: >
+        This parameter is used to find stories based on the specified entities
+        Wikipedia URL in story titles. You can read more about working with
+        entities [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: entities.title.links.wikipedia[]
       schema:
         items:
           type: string
@@ -2875,6 +2957,20 @@ components:
       explode: true
       in: query
       name: entities.title.type[]
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
+    entities_title_stock_ticker:
+      description: >
+        This parameter is used to find stories based on the specified entities
+        `stock_ticker` in story titles. You can read more about working with entities
+        [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: entities.title.stock_ticker[]
       schema:
         items:
           type: string
@@ -3140,6 +3236,21 @@ components:
         nullable: true
         type: array
       style: form
+    notentities_body_links_wikipedia:
+      description: >
+        This parameter is used to exclude stories based on the specified
+        entities Wikipedia URL in the body of stories. You can read more about
+        working with entities
+        [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: "!entities.body.links.wikipedia[]"
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
     notentities_body_text:
       description: >
         This parameter is used to exclude stories based on the specified
@@ -3170,6 +3281,21 @@ components:
         nullable: true
         type: array
       style: form
+    notentities_body_stock_ticker:
+      description: >
+        This parameter is used to exclude stories based on the specified
+        entities `stock_ticker` in the body of stories. You can read more about working
+        with entities
+        [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: "!entities.body.stock_ticker[]"
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
     notentities_title_links_dbpedia:
       description: >
         This parameter is used to exclude stories based on the specified
@@ -3179,6 +3305,21 @@ components:
       explode: true
       in: query
       name: "!entities.title.links.dbpedia[]"
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
+    notentities_title_links_wikipedia:
+      description: >
+        This parameter is used to exclude stories based on the specified
+        entities Wikipedia URL in story titles. You can read more about working
+        with entities
+        [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: "!entities.title.links.wikipedia[]"
       schema:
         items:
           type: string
@@ -3207,6 +3348,20 @@ components:
       explode: true
       in: query
       name: "!entities.title.type[]"
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
+    notentities_title_stock_ticker:
+      description: >
+        This parameter is used to exclude stories based on the specified
+        entities `stock_ticker` in story titles. You can read more about working with
+        entities [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: "!entities.title.stock_ticker[]"
       schema:
         items:
           type: string

--- a/aylien/v1/news/api.yaml
+++ b/aylien/v1/news/api.yaml
@@ -4984,127 +4984,127 @@ components:
       items:
         anyOf:
           - $ref: '#/components/schemas/Logicals'
-          - $ref: '#/components/schemas/Params'
-    Params:
-      title: Parameter defines the search query on a field
+          - $ref: '#/components/schemas/Parameter'
+    Parameter:
+      title: Query defines the search query on a field
       type: object
       properties:
         author.id:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         author.name:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         body:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         categories.confident:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         categories.id:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         categories.level:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         categories.taxonomy:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         clusters:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         links.permalink:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         entities.body.links.dbpedia:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         entities.body.text:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         entities.body.type:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         entities.title.links.dbpedia:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         entities.title.text:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         entities.title.type:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         id:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         language:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.images.content.length.max:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.images.content.length.min:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.images.count.max:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.images.count.min:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.images.format:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.images.height.max:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.images.height.min:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.images.width.max:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.images.width.min:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.videos.count.max:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         media.videos.count.min:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         sentiment.body.polarity:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         sentiment.title.polarity:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         social.shares.count.facebook.max:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         social.shares.count.facebook.min:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         social.shares.count.reddit.max:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         social.shares.count.reddit.min:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.domain:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.id:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.links.in.count.max:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.links.in.count.min:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.locations.city:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.locations.country:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.locations.state:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.rankings.alexa.country:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.rankings.alexa.rank.max:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.rankings.alexa.rank.min:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.scopes.city:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.scopes.country:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.scopes.level:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         source.scopes.state:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         story_url:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         story_language:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         text:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         title:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         translations.en.body:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         translations.en.text:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         translations.en.title:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         entity:
           oneOf:
             - $ref: '#/components/schemas/NestedEntity'
             - $ref: '#/components/schemas/Logicals'
-    Parameter:
-      title: Parameter defines the search query on a field
+    Query:
+      title: Query defines the search query on a field
       type: object
       properties:
         $eq:
@@ -5144,17 +5144,17 @@ components:
       title: To perform a nested search on entities use this.
       properties:
         name:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         sentiment:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         element:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         link.wikipedia:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         stock_ticker:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
         type:
-          $ref: '#/components/schemas/Parameter'
+          $ref: '#/components/schemas/Query'
   securitySchemes:
     app_id:
       x-auth-id-alias: true
@@ -5185,7 +5185,7 @@ components:
           schema:
             oneOf:
               - $ref: '#/components/schemas/Logicals'
-              - $ref: '#/components/schemas/Params'
+              - $ref: '#/components/schemas/Parameter'
           example:
             $and:
               - $or:

--- a/aylien/v1/news/api.yaml
+++ b/aylien/v1/news/api.yaml
@@ -5161,7 +5161,6 @@ components:
           $ref: '#/components/schemas/Parameter'
         type:
           $ref: '#/components/schemas/Parameter'
-
   securitySchemes:
     app_id:
       x-auth-id-alias: true
@@ -5193,3 +5192,19 @@ components:
             oneOf:
               - $ref: '#/components/schemas/Logicals'
               - $ref: '#/components/schemas/Params'
+          example:
+            $and:
+              - $or:
+                - body:
+                    $text: Tim Cook
+                - social.shares.count.reddit.max:
+                    $gte: 5000
+                    $boost: 5
+              - entity:
+                  $and:
+                    - name:
+                        $text: Apple
+                        $boost: 2
+                    - $not:
+                      - type:
+                          $eq: Fruit

--- a/aylien/v1/news/api.yaml
+++ b/aylien/v1/news/api.yaml
@@ -4972,15 +4972,15 @@ components:
       title: One of the logical operators such as $and, $or, $not
       type: object
       properties:
-        '$and':
+        $and:
           allOf:
             - title: Logical operator And
             - $ref: '#/components/schemas/Logical'
-        '$or':
+        $or:
           allOf:
             - title: Logical operator Or
             - $ref: '#/components/schemas/Logical'
-        '$not':
+        $not:
           allOf:
             - title: Logical operator Not
             - $ref: '#/components/schemas/Logical'
@@ -5113,36 +5113,36 @@ components:
       title: Parameter defines the search query on a field
       type: object
       properties:
-        '$eq':
+        $eq:
           title: Perform an exact match search on the given value
           anyOf: 
             - type: string
             - type: number
-        '$text':
+        $text:
           title: Perform a text search on the given value
           anyOf: 
             - type: string
             - type: number
-        '$in':
+        $in:
           title: Perform a search on an array of values
           type: array
           items: 
             anyOf:
               - type: string
               - type: number
-        '$gt':
+        $gt:
           title: Perform a greater than search on the given value
           type: number
-        '$gte':
+        $gte:
           title: Perform a greater than equal search on the given value
           type: number
-        '$lt':
+        $lt:
           title: Perform a less than search on the given value
           type: number
-        '$lte':
+        $lte:
           title: Perform a less than equal search on the given value
           type: number
-        '$boost':
+        $boost:
           title: Gives a weight to the field on performing the query
           type: number        
     NestedEntity:

--- a/aylien/v1/news/config/go.json
+++ b/aylien/v1/news/config/go.json
@@ -1,4 +1,4 @@
 {
   "packageName": "newsapi",
-  "packageVersion": "4.2.1"
+  "packageVersion": "4.2.0"
 }

--- a/aylien/v1/news/config/go.json
+++ b/aylien/v1/news/config/go.json
@@ -1,4 +1,4 @@
 {
   "packageName": "newsapi",
-  "packageVersion": "4.1.1"
+  "packageVersion": "4.2.1"
 }

--- a/aylien/v1/news/config/javascript.json
+++ b/aylien/v1/news/config/javascript.json
@@ -1,7 +1,7 @@
 {
   "projectName": "aylien-news-api",
   "moduleName": "AylienNewsApi",
-  "projectVersion": "4.2.1",
+  "projectVersion": "4.2.0",
   "licenseName": "Apache License, Version 2.0",
   "modelPropertyNaming": "camelCase"
 }

--- a/aylien/v1/news/config/javascript.json
+++ b/aylien/v1/news/config/javascript.json
@@ -1,7 +1,7 @@
 {
   "projectName": "aylien-news-api",
   "moduleName": "AylienNewsApi",
-  "projectVersion": "4.1.1",
+  "projectVersion": "4.2.1",
   "licenseName": "Apache License, Version 2.0",
   "modelPropertyNaming": "camelCase"
 }

--- a/aylien/v1/news/config/python.json
+++ b/aylien/v1/news/config/python.json
@@ -1,5 +1,5 @@
 {
   "packageName": "aylien_news_api",
   "projectName": "aylien_news_api",
-  "packageVersion": "4.2.1"
+  "packageVersion": "4.2.0"
 }

--- a/aylien/v1/news/config/python.json
+++ b/aylien/v1/news/config/python.json
@@ -1,5 +1,5 @@
 {
   "packageName": "aylien_news_api",
   "projectName": "aylien_news_api",
-  "packageVersion": "4.1.1"
+  "packageVersion": "4.2.1"
 }

--- a/aylien/v1/news/config/ruby.json
+++ b/aylien/v1/news/config/ruby.json
@@ -1,6 +1,6 @@
 {
   "gemName": "aylien_news_api",
-  "gemVersion": "4.2.1",
+  "gemVersion": "4.2.0",
   "moduleName": "AylienNewsApi",
   "gemHomepage": "https://newsapi.aylien.com/",
   "gemLicense": "Apache-2.0",

--- a/aylien/v1/news/config/ruby.json
+++ b/aylien/v1/news/config/ruby.json
@@ -1,6 +1,6 @@
 {
   "gemName": "aylien_news_api",
-  "gemVersion": "4.1.1",
+  "gemVersion": "4.2.1",
   "moduleName": "AylienNewsApi",
   "gemHomepage": "https://newsapi.aylien.com/",
   "gemLicense": "Apache-2.0",

--- a/samples/README.md
+++ b/samples/README.md
@@ -17,21 +17,6 @@ cd samples/javascript
 NEWSAPI_APP_ID=YOUR_APP_ID_HERE NEWSAPI_APP_KEY=YOUR_APP_EY_HERE node index.js
 ```
 
-### PHP
-
-The sample for PHP is requiring the `autoload.php` file of the SDK, but you need to build the SDK in order to generate that file.
-
-```
-cd sdks/news-api/php
-composer install
-```
-
-And then run the samples by providing your APP_ID and APP_KEY through environment variables:
-```
-cd samples/php
-NEWSAPI_APP_ID=YOUR_APP_ID_HERE NEWSAPI_APP_KEY=YOUR_APP_EY_HERE php -f index.php
-```
-
 ### Python
 
 The sample for Python is set up using Python 3.7.4, so you have to install python 3.7.4 (preferrably using [`pyenv`](https://github.com/pyenv/pyenv)) and then install the package on:
@@ -68,28 +53,13 @@ cd samples/ruby
 NEWSAPI_APP_ID=YOUR_APP_ID_HERE NEWSAPI_APP_KEY=YOUR_APP_EY_HERE ruby index.rb
 ```
 
-### Java
-
-The Java sample has a linked `target` to the SDK, but you have to build the SDK first:
-
-```
-cd sdks/news-api/java
-mvn clean package
-```
-
-And then run the samples by providing your APP_ID and APP_KEY through environment variables:
-```
-cd samples/java
-NEWSAPI_APP_ID=YOUR_APP_ID_HERE NEWSAPI_APP_KEY=YOUR_APP_EY_HERE javac -cp 'target/*:target/lib/*:.' Main.java && java -cp 'target/*:target/lib/*:.' Main
-```
-
 ### Go
 
 The Golang sample requires you to have the SDK linked inside your GOPATH. The suggested approach is to link the SDK directory inside your GOPATH and install the dependencies:
 
 ```
 mkdir -p $GOPATH/src/github.com/AYLIEN/
-ln -s /absolute/path/to/sdks/news-api/go $GOPATH/src/github.com/AYLIEN/aylien_newsapi_go
+ln -s /absolute/path/to/sdks/news-api/go $GOPATH/src/github.com/AYLIEN/aylien_newsapi_go/v4
 
 go get github.com/stretchr/testify/assert
 go get golang.org/x/oauth2
@@ -101,15 +71,4 @@ And then run the samples by providing your APP_ID and APP_KEY through environmen
 ```
 cd samples/go
 NEWSAPI_APP_ID=YOUR_APP_ID_HERE NEWSAPI_APP_KEY=YOUR_APP_EY_HERE go run index.go
-```
-
-### C#
-
-Build the SDK through Visual Studio and copy the sdk's dll to `csharp/Aylien.NewsApi.dll`. Run the program with:
-
-```
-set X-AYLIEN-NewsAPI-Application-ID=YOUR_APP_ID_HERE
-set X-AYLIEN-NewsAPI-Application-Key=YOUR_APP_EY_HERE
-cd samples/csharp
-index.exe
 ```

--- a/samples/README.md
+++ b/samples/README.md
@@ -41,7 +41,7 @@ To test the Ruby SDK you need to first build and install the gem:
 ```
 cd sdks/news-api/ruby
 gem build aylien_news_api.gemspec
-gem install aylien_news_api-<VERSION>.gem
+gem install ./aylien_news_api-<VERSION>.gem
 ```
 
 (If you get an error about the gem containing itself, try removing `aylien_news_api-<VERSION>.gem` first)

--- a/samples/go/index.go
+++ b/samples/go/index.go
@@ -4,8 +4,9 @@ package main
 import (
 	"context"
 	"fmt"
-	newsapi "github.com/AYLIEN/aylien_newsapi_go/v4"
 	"os"
+
+	newsapi "github.com/AYLIEN/aylien_newsapi_go/v4"
 
 	"github.com/antihax/optional"
 )
@@ -37,6 +38,28 @@ func main() {
 	_ = res
 
 	for _, story := range storiesResponse.Stories {
+		fmt.Println(story.Title, " / ", story.Source.Name)
+	}
+
+	fmt.Println("AdvancedListStories")
+	params := &newsapi.AdvancedListStoriesOpts{
+		PublishedAtStart: optional.NewString("NOW-7DAYS"),
+		PublishedAtEnd:   optional.NewString("NOW"),
+	}
+
+	body := map[string]interface{}{
+		"title": map[string]interface{}{
+			"$text": "Trump",
+		},
+	}
+
+	advancedStoriesResponse, advancedRes, advancedErr := api.AdvancedListStories(context.Background(), body, params)
+	if advancedErr != nil {
+		panic(advancedErr)
+	}
+	_ = advancedRes
+
+	for _, story := range advancedStoriesResponse.Stories {
 		fmt.Println(story.Title, " / ", story.Source.Name)
 	}
 }

--- a/samples/javascript/index.js
+++ b/samples/javascript/index.js
@@ -35,3 +35,8 @@ var callback = function(error, data, response) {
 };
 
 api.listStories(opts, callback);
+api.advancedListStories({
+  "title": {
+    "$text": "Trump"
+  }
+}, {sortBy: "social_shares_count.facebook"}, callback)

--- a/samples/python/post_search.py
+++ b/samples/python/post_search.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import os
 import aylien_news_api
-from aylien_news_api.models import Params, Parameter
+from aylien_news_api.models import Query, Parameter
 from aylien_news_api.rest import ApiException
 from pprint import pprint
 
@@ -16,8 +16,8 @@ api_instance = aylien_news_api.DefaultApi(client)
 
 try:
     api_response = api_instance.advanced_list_stories(
-        Params(
-            title=Parameter(
+        Parameter(
+            title=Query(
                 text="Trump"
             )
         )

--- a/samples/python/post_search.py
+++ b/samples/python/post_search.py
@@ -1,0 +1,27 @@
+from __future__ import print_function
+import os
+import aylien_news_api
+from aylien_news_api.models import Params, Parameter
+from aylien_news_api.rest import ApiException
+from pprint import pprint
+
+configuration = aylien_news_api.Configuration()
+configuration.api_key['X-AYLIEN-NewsAPI-Application-ID'] = os.environ.get(
+    'NEWSAPI_APP_ID')
+configuration.api_key['X-AYLIEN-NewsAPI-Application-Key'] = os.environ.get(
+    'NEWSAPI_APP_KEY')
+
+client = aylien_news_api.ApiClient(configuration)
+api_instance = aylien_news_api.DefaultApi(client)
+
+try:
+    api_response = api_instance.advanced_list_stories(
+        Params(
+            title=Parameter(
+                text="Trump"
+            )
+        )
+    )
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling DefaultApi->list_stories: %s\n" % e)

--- a/samples/ruby/index.rb
+++ b/samples/ruby/index.rb
@@ -30,3 +30,18 @@ rescue AylienNewsApi::ApiError => e
   puts "Exception when calling DefaultApi->list_stories: #{e}"
   puts e.response_body
 end
+
+begin
+  result = api_instance.advanced_list_stories(
+    AylienNewsApi::Parameter.new(
+      title: AylienNewsApi::Query.new(
+        text: "Trump"
+      )
+    ), {sort_by: 'social_shares_count.facebook'})
+  result.stories.each do |story|
+    puts "#{story.title} / #{story.source.name}"
+  end
+rescue AylienNewsApi::ApiError => e
+  puts "Exception when calling DefaultApi->advanced_list_stories: #{e}"
+  puts e.response_body
+end

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,6 +14,8 @@ sh ./install-openapi-generator.sh
 
 The SDKs are generated from the API definition files found in the [`/aylien/v1/`](/aylien/v1) directory. There are also JSON configuration files in these directories for each language (see [`/aylien/v1/news/config`](/aylien/v1/news/config) for example). This process is automatic using the `generate-sdks.sh` script.
 
+> Note: Make sure you have `gsed` installed.
+
 ```
 sh ./generate-sdks.sh
 ```

--- a/scripts/generate-sdks.sh
+++ b/scripts/generate-sdks.sh
@@ -26,23 +26,31 @@ if [ "$OS" = 'Darwin' ]; then
 fi
 cat ../aylien/v1/news/api.yaml | tr '\n' '\r' | $cmd -e 's/\s\s\+tags:\r\s*- \w*//g' | tr '\r' '\n' > temp.api.yaml
 
+python remove-post-body.py temp.api.yaml no-post.api.yaml
+
 for lang in "ruby" "javascript" "go" "python"
 do
-    echo "Building ${lang} ..."
-    $OPENAPI_CMD generate \
-        --skip-validate-spec \
-        --input-spec "../aylien/v1/text/api.yaml" \
-        --generator-name "${lang}" \
-        --output "../sdks/text-api/${lang}"
-    $OPENAPI_CMD generate \
-        --skip-validate-spec \
-        --input-spec "temp.api.yaml" \
-        --generator-name "${lang}" \
-        --config "../aylien/v1/news/config/${lang}.json" \
-        --output "../sdks/news-api/${lang}"
+  f="temp.api.yaml"
+  if [[ "$lang" == "javascript" || "$lang" == "go" ]]; then
+    f="no-post.api.yaml"
+  fi
+
+  echo "Building ${lang} ..."
+  $OPENAPI_CMD generate \
+      --skip-validate-spec \
+      --input-spec "../aylien/v1/text/api.yaml" \
+      --generator-name "${lang}" \
+      --output "../sdks/text-api/${lang}"
+  $OPENAPI_CMD generate \
+      --skip-validate-spec \
+      --input-spec "$f" \
+      --generator-name "${lang}" \
+      --config "../aylien/v1/news/config/${lang}.json" \
+      --output "../sdks/news-api/${lang}"
 done
 
 rm temp.api.yaml
+rm no-post.api.yaml
 
 echo "All done!"
 

--- a/scripts/remove-post-body.py
+++ b/scripts/remove-post-body.py
@@ -1,0 +1,24 @@
+from yaml import load, dump
+import sys
+
+if len(sys.argv) < 3:
+    print("""remove-post-body.py <input_file> <output_file>
+
+Example:
+remove-post-body.py aylien/v1/news/api.yaml temp-no-post.yaml
+
+Used to remove post `requestBody` definition from all endpoints to ensure
+Node and Go SDKs generate properly.""")
+    sys.exit(0)
+
+s = open(sys.argv[1])
+output = open(sys.argv[2], 'w')
+definition = load(s)
+
+parameters = list(definition['components']['parameters'].values())
+
+for value in definition['paths'].values():
+    if 'post' in value and 'requestBody' in value['post']:
+        value['post'].pop('requestBody', None)
+
+dump(definition, output)

--- a/scripts/remove-post-body.py
+++ b/scripts/remove-post-body.py
@@ -19,7 +19,17 @@ parameters = list(definition['components']['parameters'].values())
 
 for value in definition['paths'].values():
     if 'post' in value and 'requestBody' in value['post']:
-        value['post'].pop('requestBody', None)
+        value['post']['requestBody'] = {
+            'required': True,
+            'description': '/stories body schema to perform an advanced search with logical operators and nested objects.\n',
+            'content': {
+                'application/json': {
+                    'schema': {
+                        'type': 'object'
+                    }
+                }
+            }
+        }
 
 for value in ['Logical', 'Logicals', 'Parameter', 'Query', 'NestedEntity']:
     definition['components']['schemas'].pop(value, None)

--- a/scripts/remove-post-body.py
+++ b/scripts/remove-post-body.py
@@ -21,4 +21,9 @@ for value in definition['paths'].values():
     if 'post' in value and 'requestBody' in value['post']:
         value['post'].pop('requestBody', None)
 
+for value in ['Logical', 'Logicals', 'Parameter', 'Query', 'NestedEntity']:
+    definition['components']['schemas'].pop(value, None)
+
+definition['components'].pop('requestBodies', None)
+
 dump(definition, output)


### PR DESCRIPTION
regarding /coverages endpoint:

We initially decided we will keep it until we launch Solo and we will deprecate it later on, but Marketing said it’s better to have a larger change at one point in time rather than multiple changes over time, as such, they suggested if we can, let’s deprecate it now. So now we are removing coverages from our SDKs. We will keep the endpoint available until 31st August (DO shutdown date, might change a bit), then remove it altogether. This is a bit tricky as both SDKs and API are generated from specification, so we will need a temporary branch with coverages for our api-news while SDKs use master.