### PR TITLE
feat: [ch6500] complex warning object

### DIFF
--- a/aylien/v1/news/api-docs.yaml
+++ b/aylien/v1/news/api-docs.yaml
@@ -4003,6 +4003,8 @@ components:
       properties:
         about:
           type: string
+        docs:
+          type: string  
       type: object
     Errors:
       properties:
@@ -4318,9 +4320,11 @@ components:
           description: The start of a period in which searched stories were published
           format: date-time
           type: string
-        warning:
+        warnings:
           description: Notifies about possible issues that occurred when searching for stories
-          type: string
+          items:
+            $ref: "#/components/schemas/Warning"
+          type: array
       type: object
     Story:
       properties:
@@ -4525,6 +4529,18 @@ components:
           description: The start of a period in which searched stories were published
           format: date-time
           type: string
+      type: object
+    Warning:
+      properties:
+        id:
+          description: The identfier of the warning, represents its origin.
+          type: String
+        links:
+          description: Contians links to the documentation.
+          $ref: "#/components/schemas/ErrorLinks"
+        detail:
+          description: The detailed description of the warning.
+          type: String
       type: object
   securitySchemes:
     app_id:

--- a/aylien/v1/news/api.yaml
+++ b/aylien/v1/news/api.yaml
@@ -3986,6 +3986,8 @@ components:
       properties:
         about:
           type: string
+        docs:
+          type: string  
       type: object
     Errors:
       properties:
@@ -4301,9 +4303,11 @@ components:
           description: The start of a period in which searched stories were published
           format: date-time
           type: string
-        warning:
+        warnings:
           description: Notifies about possible issues that occurred when searching for stories
-          type: string
+          items:
+            $ref: "#/components/schemas/Warning"
+          type: array
       type: object
     Story:
       properties:
@@ -4508,6 +4512,18 @@ components:
           description: The start of a period in which searched stories were published
           format: date-time
           type: string
+      type: object
+    Warning:
+      properties:
+        id:
+          description: The identfier of the warning, represents its origin.
+          type: String
+        links:
+          description: Contians links to the documentation.
+          $ref: "#/components/schemas/ErrorLinks"
+        detail:
+          description: The detailed description of the warning.
+          type: String
       type: object
   securitySchemes:
     app_id:


### PR DESCRIPTION
Simple `warning` text field is changed to `warnings` that is an array of complex object.

Note that I added also a missing `docs` field to `ErrorLinks` - I am not sure of that field is left missing deliberately so please validate it.