### PR TITLE
feat(ch8779): new entities schema (surface_forms, id)

### DIFF
--- a/aylien/v1/news/api-docs.yaml
+++ b/aylien/v1/news/api-docs.yaml
@@ -4777,8 +4777,19 @@ components:
         id:
           description: The unique ID of the entity
           type: string
+        indices:
+          description: The indices of the entity text
+          items:
+            items:
+              format: int32
+              type: integer
+            type: array
+          type: array
         links:
           $ref: "#/components/schemas/EntityLinks"
+        text:
+          description: The entity text
+          type: string
         stock_ticker:
           description: The stock_ticker of the entity (might be null)
           type: string

--- a/aylien/v1/news/api-docs.yaml
+++ b/aylien/v1/news/api-docs.yaml
@@ -516,6 +516,10 @@ paths:
         - $ref: "#/components/parameters/notcategories_label"
         - $ref: "#/components/parameters/categories_level"
         - $ref: "#/components/parameters/notcategories_level"
+        - $ref: "#/components/parameters/entities_title_id"
+        - $ref: "#/components/parameters/notentities_title_id"
+        - $ref: "#/components/parameters/entities_title_surface_forms_text"
+        - $ref: "#/components/parameters/notentities_title_surface_forms_text"
         - $ref: "#/components/parameters/entities_title_text"
         - $ref: "#/components/parameters/notentities_title_text"
         - $ref: "#/components/parameters/entities_title_type"
@@ -528,6 +532,10 @@ paths:
         - $ref: "#/components/parameters/notentities_title_links_wikipedia"
         - $ref: "#/components/parameters/entities_title_links_wikidata"
         - $ref: "#/components/parameters/notentities_title_links_wikidata"
+        - $ref: "#/components/parameters/entities_body_id"
+        - $ref: "#/components/parameters/notentities_body_id"
+        - $ref: "#/components/parameters/entities_body_surface_forms_text"
+        - $ref: "#/components/parameters/notentities_body_surface_forms_text"
         - $ref: "#/components/parameters/entities_body_text"
         - $ref: "#/components/parameters/notentities_body_text"
         - $ref: "#/components/parameters/entities_body_type"
@@ -1021,6 +1029,10 @@ paths:
       - $ref: "#/components/parameters/notcategories_label"
       - $ref: "#/components/parameters/categories_level"
       - $ref: "#/components/parameters/notcategories_level"
+      - $ref: "#/components/parameters/entities_title_id"
+      - $ref: "#/components/parameters/notentities_title_id"
+      - $ref: "#/components/parameters/entities_title_surface_forms_text"
+      - $ref: "#/components/parameters/notentities_title_surface_forms_text"
       - $ref: "#/components/parameters/entities_title_text"
       - $ref: "#/components/parameters/notentities_title_text"
       - $ref: "#/components/parameters/entities_title_type"
@@ -1033,6 +1045,10 @@ paths:
       - $ref: "#/components/parameters/notentities_title_links_wikipedia"
       - $ref: "#/components/parameters/entities_title_links_wikidata"
       - $ref: "#/components/parameters/notentities_title_links_wikidata"
+      - $ref: "#/components/parameters/entities_body_id"
+      - $ref: "#/components/parameters/notentities_body_id"
+      - $ref: "#/components/parameters/entities_body_surface_forms_text"
+      - $ref: "#/components/parameters/notentities_body_surface_forms_text"
       - $ref: "#/components/parameters/entities_body_text"
       - $ref: "#/components/parameters/notentities_body_text"
       - $ref: "#/components/parameters/entities_body_type"
@@ -1349,6 +1365,10 @@ paths:
         - $ref: "#/components/parameters/notcategories_label"
         - $ref: "#/components/parameters/categories_level"
         - $ref: "#/components/parameters/notcategories_level"
+        - $ref: "#/components/parameters/entities_title_id"
+        - $ref: "#/components/parameters/notentities_title_id"
+        - $ref: "#/components/parameters/entities_title_surface_forms_text"
+        - $ref: "#/components/parameters/notentities_title_surface_forms_text"
         - $ref: "#/components/parameters/entities_title_text"
         - $ref: "#/components/parameters/notentities_title_text"
         - $ref: "#/components/parameters/entities_title_type"
@@ -1361,6 +1381,10 @@ paths:
         - $ref: "#/components/parameters/notentities_title_links_wikipedia"
         - $ref: "#/components/parameters/entities_title_links_wikidata"
         - $ref: "#/components/parameters/notentities_title_links_wikidata"
+        - $ref: "#/components/parameters/entities_body_id"
+        - $ref: "#/components/parameters/notentities_body_id"
+        - $ref: "#/components/parameters/entities_body_surface_forms_text"
+        - $ref: "#/components/parameters/notentities_body_surface_forms_text"
         - $ref: "#/components/parameters/entities_body_text"
         - $ref: "#/components/parameters/notentities_body_text"
         - $ref: "#/components/parameters/entities_body_type"
@@ -2292,6 +2316,10 @@ paths:
         - $ref: "#/components/parameters/notcategories_label"
         - $ref: "#/components/parameters/categories_level"
         - $ref: "#/components/parameters/notcategories_level"
+        - $ref: "#/components/parameters/entities_title_id"
+        - $ref: "#/components/parameters/notentities_title_id"
+        - $ref: "#/components/parameters/entities_title_surface_forms_text"
+        - $ref: "#/components/parameters/notentities_title_surface_forms_text"
         - $ref: "#/components/parameters/entities_title_text"
         - $ref: "#/components/parameters/notentities_title_text"
         - $ref: "#/components/parameters/entities_title_type"
@@ -2304,6 +2332,10 @@ paths:
         - $ref: "#/components/parameters/notentities_title_links_wikipedia"
         - $ref: "#/components/parameters/entities_title_links_wikidata"
         - $ref: "#/components/parameters/notentities_title_links_wikidata"
+        - $ref: "#/components/parameters/entities_body_id"
+        - $ref: "#/components/parameters/notentities_body_id"
+        - $ref: "#/components/parameters/entities_body_surface_forms_text"
+        - $ref: "#/components/parameters/notentities_body_surface_forms_text"
         - $ref: "#/components/parameters/entities_body_text"
         - $ref: "#/components/parameters/notentities_body_text"
         - $ref: "#/components/parameters/entities_body_type"
@@ -2538,6 +2570,10 @@ paths:
         - $ref: "#/components/parameters/notcategories_label"
         - $ref: "#/components/parameters/categories_level"
         - $ref: "#/components/parameters/notcategories_level"
+        - $ref: "#/components/parameters/entities_title_id"
+        - $ref: "#/components/parameters/notentities_title_id"
+        - $ref: "#/components/parameters/entities_title_surface_forms_text"
+        - $ref: "#/components/parameters/notentities_title_surface_forms_text"
         - $ref: "#/components/parameters/entities_title_text"
         - $ref: "#/components/parameters/notentities_title_text"
         - $ref: "#/components/parameters/entities_title_type"
@@ -2550,6 +2586,10 @@ paths:
         - $ref: "#/components/parameters/notentities_title_links_wikipedia"
         - $ref: "#/components/parameters/entities_title_links_wikidata"
         - $ref: "#/components/parameters/notentities_title_links_wikidata"
+        - $ref: "#/components/parameters/entities_body_id"
+        - $ref: "#/components/parameters/notentities_body_id"
+        - $ref: "#/components/parameters/entities_body_surface_forms_text"
+        - $ref: "#/components/parameters/notentities_body_surface_forms_text"
         - $ref: "#/components/parameters/entities_body_text"
         - $ref: "#/components/parameters/notentities_body_text"
         - $ref: "#/components/parameters/entities_body_type"
@@ -2811,7 +2851,7 @@ components:
           type: string
         nullable: true
         type: array
-      style: form  
+      style: form
     categories_level:
       description: >
         This parameter is used for finding stories by categories level. You can
@@ -2879,6 +2919,20 @@ components:
         nullable: true
         type: array
       style: form
+    entities_body_id:
+      description: >
+        This parameter is used to find stories based on the specified entities
+        `id` in the body of stories. You can read more about working with
+        entities [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: entities.body.id[]
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
     entities_body_links_dbpedia:
       description: >
         This parameter is used to find stories based on the specified entities
@@ -2915,6 +2969,20 @@ components:
       explode: true
       in: query
       name: entities.body.links.wikidata[]
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
+    entities_body_surface_forms_text:
+      description: >
+        This parameter is used to find stories based on the specified entities
+        `surface_form` in the body of stories. You can read more about working with
+        entities [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: entities.body.surface_forms.text[]
       schema:
         items:
           type: string
@@ -2963,6 +3031,20 @@ components:
         nullable: true
         type: array
       style: form
+    entities_title_id:
+      description: >
+        This parameter is used to find stories based on the specified entities
+        `id` in the title of stories. You can read more about working with
+        entities [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: entities.title.id[]
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
     entities_title_links_dbpedia:
       description: >
         This parameter is used to find stories based on the specified entities
@@ -2999,6 +3081,20 @@ components:
       explode: true
       in: query
       name: entities.title.links.wikidata[]
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
+    entities_title_surface_forms_text:
+      description: >
+        This parameter is used to find stories based on the specified entities
+        `surface_form` in story titles. You can read more about working with entities
+        [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: entities.title.surface_forms.text[]
       schema:
         items:
           type: string
@@ -3276,7 +3372,7 @@ components:
           type: string
         nullable: true
         type: array
-      style: form  
+      style: form
     notcategories_level:
       description: >
         This parameter is used for excluding stories by categories level. You
@@ -3288,6 +3384,21 @@ components:
       schema:
         items:
           type: integer
+        nullable: true
+        type: array
+      style: form
+    notentities_body_id:
+      description: >
+        This parameter is used to exclude stories based on the specified
+        entities `id` in the body of stories. You can read more about working
+        with entities
+        [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: "!entities.body.id[]"
+      schema:
+        items:
+          type: string
         nullable: true
         type: array
       style: form
@@ -3330,6 +3441,21 @@ components:
       explode: true
       in: query
       name: "!entities.body.links.wikidata[]"
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
+    notentities_body_surface_forms_text:
+      description: >
+        This parameter is used to exclude stories based on the specified
+        entities `surface_form` in the body of stories. You can read more about working
+        with entities
+        [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: "!entities.body.surface_forms.text[]"
       schema:
         items:
           type: string
@@ -3381,6 +3507,20 @@ components:
         nullable: true
         type: array
       style: form
+    notentities_title_id:
+      description: >
+        This parameter is used to exclude stories based on the specified
+        entities `id` in story titles. You can read more about working with
+        entities [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: "!entities.title.id[]"
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
     notentities_title_links_dbpedia:
       description: >
         This parameter is used to exclude stories based on the specified
@@ -3420,6 +3560,20 @@ components:
       explode: true
       in: query
       name: "!entities.title.links.wikidata[]"
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
+    notentities_title_surface_forms_text:
+      description: >
+        This parameter is used to exclude stories based on the specified
+        entities `surface_form` in story titles. You can read more about working with
+        entities [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: "!entities.title.surface_forms.text[]"
       schema:
         items:
           type: string
@@ -4534,7 +4688,7 @@ components:
           type: string
         label:
           description: The label of the category
-          type: string  
+          type: string
         level:
           description: The level of the category
           format: int32
@@ -4620,19 +4774,11 @@ components:
       type: object
     Entity:
       properties:
-        indices:
-          description: The indices of the entity text
-          items:
-            items:
-              format: int32
-              type: integer
-            type: array
-          type: array
+        id:
+          description: The unique ID of the entity
+          type: string
         links:
           $ref: "#/components/schemas/EntityLinks"
-        text:
-          description: The entity text
-          type: string
         stock_ticker:
           description: The stock_ticker of the entity (might be null)
           type: string
@@ -4643,8 +4789,26 @@ components:
             type: string
           type: array
         sentiment:
-          $ref: "#/components/schemas/EntitySentiment"  
+          $ref: "#/components/schemas/EntitySentiment"
+        surface_forms:
+          items:
+            $ref: "#/components/schemas/EntitySurfaceForm"
+          type: array
       type: object
+  EntitySurfaceForm:
+    properties:
+      text:
+        description: The entity text
+        type: string
+      indices:
+        description: The indices of the entity text
+        items:
+          items:
+            format: int32
+            type: integer
+          type: array
+        type: array
+    type: object
     EntityLinks:
       properties:
         dbpedia:
@@ -4688,7 +4852,7 @@ components:
         about:
           type: string
         docs:
-          type: string  
+          type: string
       type: object
     Errors:
       properties:
@@ -4736,7 +4900,7 @@ components:
         published_at.start:
           description: The start of a period in which searched stories were published
           format: date-time
-          type: string  
+          type: string
       type: object
     Location:
       properties:
@@ -4839,7 +5003,7 @@ components:
         published_at.start:
           description: The start of a period in which searched stories were published
           format: date-time
-          type: string  
+          type: string
       type: object
     RepresentativeStory:
       properties:
@@ -5194,8 +5358,8 @@ components:
     AggregatedSentiment:
       description: The aggregation of sentiments
       type: object
-      properties: 
-        positive: 
+      properties:
+        positive:
           description: Positive sentiments count
           format: int32
           type: integer
@@ -5250,7 +5414,7 @@ components:
           description: The detailed description of the warning.
           type: string
       type: object
-    Logicals: 
+    Logicals:
       title: One of the logical operators such as $and, $or, $not
       type: object
       properties:
@@ -5391,18 +5555,18 @@ components:
       properties:
         $eq:
           title: Perform an exact match search on the given value
-          oneOf: 
+          oneOf:
             - type: string
             - type: number
         $text:
           title: Perform a text search on the given value
-          oneOf: 
+          oneOf:
             - type: string
             - type: number
         $in:
           title: Perform a search on an array of values
           type: array
-          items: 
+          items:
             oneOf:
               - type: string
               - type: number
@@ -5420,12 +5584,17 @@ components:
           type: number
         $boost:
           title: Gives a weight to the field on performing the query
-          type: number        
+          type: number
     NestedEntity:
       type: object
       title: To perform a nested search on entities use this.
       properties:
+        id:
+          description: The unique ID of the entity
+          type: string
         name:
+          $ref: '#/components/schemas/Query'
+        surface_forms.text:
           $ref: '#/components/schemas/Query'
         sentiment:
           $ref: '#/components/schemas/Query'

--- a/aylien/v1/news/api.yaml
+++ b/aylien/v1/news/api.yaml
@@ -2792,7 +2792,7 @@ components:
           type: string
         nullable: true
         type: array
-      style: form  
+      style: form
     categories_level:
       description: >
         This parameter is used for finding stories by categories level. You can
@@ -2854,6 +2854,20 @@ components:
       explode: true
       in: query
       name: "!links.permalink[]"
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
+    entities_body_id:
+      description: >
+        This parameter is used to find stories based on the specified entities
+        `id` in the body of stories. You can read more about working with
+        entities [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: entities.body.id[]
       schema:
         items:
           type: string
@@ -2938,6 +2952,20 @@ components:
       explode: true
       in: query
       name: entities.body.stock_ticker[]
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
+    entities_title_id:
+      description: >
+        This parameter is used to find stories based on the specified entities
+        `id` in the title of stories. You can read more about working with
+        entities [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: entities.title.id[]
       schema:
         items:
           type: string
@@ -3257,7 +3285,7 @@ components:
           type: string
         nullable: true
         type: array
-      style: form  
+      style: form
     notcategories_level:
       description: >
         This parameter is used for excluding stories by categories level. You
@@ -4515,7 +4543,7 @@ components:
           type: string
         label:
           description: The label of the category
-          type: string  
+          type: string
         level:
           description: The level of the category
           format: int32
@@ -4601,19 +4629,11 @@ components:
       type: object
     Entity:
       properties:
-        indices:
-          description: The indices of the entity text
-          items:
-            items:
-              format: int32
-              type: integer
-            type: array
-          type: array
+        id:
+          description: The unique ID of the entity
+          type: string
         links:
           $ref: "#/components/schemas/EntityLinks"
-        text:
-          description: The entity text
-          type: string
         stock_ticker:
           description: The stock_ticker of the entity (might be null)
           type: string
@@ -4624,7 +4644,25 @@ components:
             type: string
           type: array
         sentiment:
-          $ref: "#/components/schemas/EntitySentiment"  
+          $ref: "#/components/schemas/EntitySentiment"
+        surface_forms:
+          items:
+            $ref: "#/components/schemas/EntitySurfaceForm"
+          type: array
+      type: object
+    EntitySurfaceForm:
+      properties:
+        text:
+          description: The entity text
+          type: string
+        indices:
+          description: The indices of the entity text
+          items:
+            items:
+              format: int32
+              type: integer
+            type: array
+          type: array
       type: object
     EntityLinks:
       properties:
@@ -4669,7 +4707,7 @@ components:
         about:
           type: string
         docs:
-          type: string  
+          type: string
       type: object
     Errors:
       properties:
@@ -4717,7 +4755,7 @@ components:
         published_at.start:
           description: The start of a period in which searched stories were published
           format: date-time
-          type: string  
+          type: string
       type: object
     Location:
       properties:
@@ -4820,7 +4858,7 @@ components:
         published_at.start:
           description: The start of a period in which searched stories were published
           format: date-time
-          type: string  
+          type: string
       type: object
     RepresentativeStory:
       properties:
@@ -5175,8 +5213,8 @@ components:
     AggregatedSentiment:
       description: The aggregation of sentiments
       type: object
-      properties: 
-        positive: 
+      properties:
+        positive:
           description: Positive sentiments count
           format: int32
           type: integer
@@ -5231,7 +5269,7 @@ components:
           description: The detailed description of the warning.
           type: string
       type: object
-    Logicals: 
+    Logicals:
       title: One of the logical operators such as $and, $or, $not
       type: object
       properties:
@@ -5372,18 +5410,18 @@ components:
       properties:
         $eq:
           title: Perform an exact match search on the given value
-          oneOf: 
+          oneOf:
             - type: string
             - type: number
         $text:
           title: Perform a text search on the given value
-          oneOf: 
+          oneOf:
             - type: string
             - type: number
         $in:
           title: Perform a search on an array of values
           type: array
-          items: 
+          items:
             oneOf:
               - type: string
               - type: number
@@ -5401,7 +5439,7 @@ components:
           type: number
         $boost:
           title: Gives a weight to the field on performing the query
-          type: number        
+          type: number
     NestedEntity:
       type: object
       title: To perform a nested search on entities use this.

--- a/aylien/v1/news/api.yaml
+++ b/aylien/v1/news/api.yaml
@@ -4758,8 +4758,19 @@ components:
         id:
           description: The unique ID of the entity
           type: string
+        indices:
+          description: The indices of the entity text
+          items:
+            items:
+              format: int32
+              type: integer
+            type: array
+          type: array
         links:
           $ref: "#/components/schemas/EntityLinks"
+        text:
+          description: The entity text
+          type: string
         stock_ticker:
           description: The stock_ticker of the entity (might be null)
           type: string

--- a/aylien/v1/news/api.yaml
+++ b/aylien/v1/news/api.yaml
@@ -507,6 +507,10 @@ paths:
         - $ref: "#/components/parameters/notcategories_label"
         - $ref: "#/components/parameters/categories_level"
         - $ref: "#/components/parameters/notcategories_level"
+        - $ref: "#/components/parameters/entities_title_id"
+        - $ref: "#/components/parameters/notentities_title_id"
+        - $ref: "#/components/parameters/entities_title_surface_forms_text"
+        - $ref: "#/components/parameters/notentities_title_surface_forms_text"
         - $ref: "#/components/parameters/entities_title_text"
         - $ref: "#/components/parameters/notentities_title_text"
         - $ref: "#/components/parameters/entities_title_type"
@@ -519,6 +523,10 @@ paths:
         - $ref: "#/components/parameters/notentities_title_links_wikipedia"
         - $ref: "#/components/parameters/entities_title_links_wikidata"
         - $ref: "#/components/parameters/notentities_title_links_wikidata"
+        - $ref: "#/components/parameters/entities_body_id"
+        - $ref: "#/components/parameters/notentities_body_id"
+        - $ref: "#/components/parameters/entities_body_surface_forms_text"
+        - $ref: "#/components/parameters/notentities_body_surface_forms_text"
         - $ref: "#/components/parameters/entities_body_text"
         - $ref: "#/components/parameters/notentities_body_text"
         - $ref: "#/components/parameters/entities_body_type"
@@ -1010,6 +1018,10 @@ paths:
       - $ref: "#/components/parameters/notcategories_label"
       - $ref: "#/components/parameters/categories_level"
       - $ref: "#/components/parameters/notcategories_level"
+      - $ref: "#/components/parameters/entities_title_id"
+      - $ref: "#/components/parameters/notentities_title_id"
+      - $ref: "#/components/parameters/entities_title_surface_forms_text"
+      - $ref: "#/components/parameters/notentities_title_surface_forms_text"
       - $ref: "#/components/parameters/entities_title_text"
       - $ref: "#/components/parameters/notentities_title_text"
       - $ref: "#/components/parameters/entities_title_type"
@@ -1022,6 +1034,10 @@ paths:
       - $ref: "#/components/parameters/notentities_title_links_wikipedia"
       - $ref: "#/components/parameters/entities_title_links_wikidata"
       - $ref: "#/components/parameters/notentities_title_links_wikidata"
+      - $ref: "#/components/parameters/entities_body_id"
+      - $ref: "#/components/parameters/notentities_body_id"
+      - $ref: "#/components/parameters/entities_body_surface_forms_text"
+      - $ref: "#/components/parameters/notentities_body_surface_forms_text"
       - $ref: "#/components/parameters/entities_body_text"
       - $ref: "#/components/parameters/notentities_body_text"
       - $ref: "#/components/parameters/entities_body_type"
@@ -1336,6 +1352,10 @@ paths:
         - $ref: "#/components/parameters/notcategories_label"
         - $ref: "#/components/parameters/categories_level"
         - $ref: "#/components/parameters/notcategories_level"
+        - $ref: "#/components/parameters/entities_title_id"
+        - $ref: "#/components/parameters/notentities_title_id"
+        - $ref: "#/components/parameters/entities_title_surface_forms_text"
+        - $ref: "#/components/parameters/notentities_title_surface_forms_text"
         - $ref: "#/components/parameters/entities_title_text"
         - $ref: "#/components/parameters/notentities_title_text"
         - $ref: "#/components/parameters/entities_title_type"
@@ -1348,6 +1368,10 @@ paths:
         - $ref: "#/components/parameters/notentities_title_links_wikipedia"
         - $ref: "#/components/parameters/entities_title_links_wikidata"
         - $ref: "#/components/parameters/notentities_title_links_wikidata"
+        - $ref: "#/components/parameters/entities_body_id"
+        - $ref: "#/components/parameters/notentities_body_id"
+        - $ref: "#/components/parameters/entities_body_surface_forms_text"
+        - $ref: "#/components/parameters/notentities_body_surface_forms_text"
         - $ref: "#/components/parameters/entities_body_text"
         - $ref: "#/components/parameters/notentities_body_text"
         - $ref: "#/components/parameters/entities_body_type"
@@ -2275,6 +2299,10 @@ paths:
         - $ref: "#/components/parameters/notcategories_label"
         - $ref: "#/components/parameters/categories_level"
         - $ref: "#/components/parameters/notcategories_level"
+        - $ref: "#/components/parameters/entities_title_id"
+        - $ref: "#/components/parameters/notentities_title_id"
+        - $ref: "#/components/parameters/entities_title_surface_forms_text"
+        - $ref: "#/components/parameters/notentities_title_surface_forms_text"
         - $ref: "#/components/parameters/entities_title_text"
         - $ref: "#/components/parameters/notentities_title_text"
         - $ref: "#/components/parameters/entities_title_type"
@@ -2287,6 +2315,10 @@ paths:
         - $ref: "#/components/parameters/notentities_title_links_wikipedia"
         - $ref: "#/components/parameters/entities_title_links_wikidata"
         - $ref: "#/components/parameters/notentities_title_links_wikidata"
+        - $ref: "#/components/parameters/entities_body_id"
+        - $ref: "#/components/parameters/notentities_body_id"
+        - $ref: "#/components/parameters/entities_body_surface_forms_text"
+        - $ref: "#/components/parameters/notentities_body_surface_forms_text"
         - $ref: "#/components/parameters/entities_body_text"
         - $ref: "#/components/parameters/notentities_body_text"
         - $ref: "#/components/parameters/entities_body_type"
@@ -2519,6 +2551,10 @@ paths:
         - $ref: "#/components/parameters/notcategories_label"
         - $ref: "#/components/parameters/categories_level"
         - $ref: "#/components/parameters/notcategories_level"
+        - $ref: "#/components/parameters/entities_title_id"
+        - $ref: "#/components/parameters/notentities_title_id"
+        - $ref: "#/components/parameters/entities_title_surface_forms_text"
+        - $ref: "#/components/parameters/notentities_title_surface_forms_text"
         - $ref: "#/components/parameters/entities_title_text"
         - $ref: "#/components/parameters/notentities_title_text"
         - $ref: "#/components/parameters/entities_title_type"
@@ -2531,6 +2567,10 @@ paths:
         - $ref: "#/components/parameters/notentities_title_links_wikipedia"
         - $ref: "#/components/parameters/entities_title_links_wikidata"
         - $ref: "#/components/parameters/notentities_title_links_wikidata"
+        - $ref: "#/components/parameters/entities_body_id"
+        - $ref: "#/components/parameters/notentities_body_id"
+        - $ref: "#/components/parameters/entities_body_surface_forms_text"
+        - $ref: "#/components/parameters/notentities_body_surface_forms_text"
         - $ref: "#/components/parameters/entities_body_text"
         - $ref: "#/components/parameters/notentities_body_text"
         - $ref: "#/components/parameters/entities_body_type"
@@ -2916,6 +2956,20 @@ components:
         nullable: true
         type: array
       style: form
+    entities_body_surface_forms_text:
+      description: >
+        This parameter is used to find stories based on the specified entities
+        `surface_form` in the body of stories. You can read more about working with
+        entities [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: entities.body.surface_forms.text[]
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
     entities_body_text:
       description: >
         This parameter is used to find stories based on the specified entities
@@ -3008,6 +3062,20 @@ components:
       explode: true
       in: query
       name: entities.title.links.wikidata[]
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
+    entities_title_surface_forms_text:
+      description: >
+        This parameter is used to find stories based on the specified entities
+        `surface_form` in story titles. You can read more about working with entities
+        [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: entities.title.surface_forms.text[]
       schema:
         items:
           type: string
@@ -3300,6 +3368,21 @@ components:
         nullable: true
         type: array
       style: form
+    notentities_body_id:
+      description: >
+        This parameter is used to exclude stories based on the specified
+        entities `id` in the body of stories. You can read more about working
+        with entities
+        [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: "!entities.body.id[]"
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
     notentities_body_links_dbpedia:
       description: >
         This parameter is used to exclude stories based on the specified
@@ -3339,6 +3422,21 @@ components:
       explode: true
       in: query
       name: "!entities.body.links.wikidata[]"
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
+    notentities_body_surface_forms_text:
+      description: >
+        This parameter is used to exclude stories based on the specified
+        entities `surface_form` in the body of stories. You can read more about working
+        with entities
+        [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: "!entities.body.surface_forms.text[]"
       schema:
         items:
           type: string
@@ -3390,6 +3488,20 @@ components:
         nullable: true
         type: array
       style: form
+    notentities_title_id:
+      description: >
+        This parameter is used to exclude stories based on the specified
+        entities `id` in story titles. You can read more about working with
+        entities [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: "!entities.title.id[]"
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
     notentities_title_links_dbpedia:
       description: >
         This parameter is used to exclude stories based on the specified
@@ -3429,6 +3541,20 @@ components:
       explode: true
       in: query
       name: "!entities.title.links.wikidata[]"
+      schema:
+        items:
+          type: string
+        nullable: true
+        type: array
+      style: form
+    notentities_title_surface_forms_text:
+      description: >
+        This parameter is used to exclude stories based on the specified
+        entities `surface_form` in story titles. You can read more about working with
+        entities [here](https://newsapi.aylien.com/docs/working-with-entities).
+      explode: true
+      in: query
+      name: "!entities.title.surface_forms.text[]"
       schema:
         items:
           type: string
@@ -5444,7 +5570,11 @@ components:
       type: object
       title: To perform a nested search on entities use this.
       properties:
+        id:
+          $ref: '#/components/schemas/Query'
         name:
+          $ref: '#/components/schemas/Query'
+        surface_forms.text:
           $ref: '#/components/schemas/Query'
         sentiment:
           $ref: '#/components/schemas/Query'


### PR DESCRIPTION
This adds the attributes `surface_forms` and `id` to story entities, both in the response field and as search parameters.

 - `surface_forms` is a list of objects whereas each object contains one of the entity's [surface forms](https://wiki.apertium.org/wiki/Surface_form) (key `text`) and the indices at which this surface form appears in the text (key `indices`).

e.g. an entity's `surface_forms` could look as follows

```
...
stock_ticker: "RYA"
surface_forms: [{
    text: "Ryanair",
    indices: [[6, 13], [70, 77]]
},{
    text: "Ryanair Holdings plc",
    indices: [[70, 90]]
}]
...
``` 

To search stories with a specific entity surface form, the `entities.[body/text].surface_forms.text` parameter can be used. 
Note that `surface_forms` will eventually deprecate both the `text` and `indices` fields and query parameters of entities.

 - `id` is a unique identifier of an entity